### PR TITLE
pull selectors out of sqlwhat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '3.5'
 install:
 - pip install .
+- pip install -r requirements.txt
 script: py.test
 deploy:
   provider: pypi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,3 +13,15 @@ Logic
 
 .. automodule:: protowhat.checks.check_logic
     :members:
+
+AST Checks
+----------
+
+.. automodule:: protowhat.checks.check_funcs
+    :members:
+
+Ex Syntax
+==========
+
+.. automethod:: protowhat.sct_syntax.Ex.__call__
+

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -1,0 +1,231 @@
+from functools import partial, wraps
+import copy
+
+MSG_CHECK_FALLBACK = "Your submission is incorrect. Try again!"
+
+def requires_ast(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        state = kwargs.get('state', args[0] if len(args) else None)
+        ParseError = state.ast_dispatcher.ParseError
+
+        state_ast = [state.student_ast, state.solution_ast]
+        parse_fail = any(isinstance(ast, ParseError) for ast in state_ast)
+
+        if parse_fail: return state              # skip test
+        else: return f(*args, **kwargs)          # proceed with test
+
+    return wrapper
+
+@requires_ast
+def check_node(state, name, index=0, missing_msg="Could not find the {index}{node_name}.", priority=None):
+    """Select a node from abstract syntax tree (AST), using its name and index position.
+    
+    Args:
+        state: State instance describing student and solution code. Can be omitted if used with Ex().
+        name : the name of the abstract syntax tree node to find.
+        index: the position of that node (see below for details).
+        missing_msg: feedback message if node is not in student AST.
+        priority: the priority level of the node being searched for. This determines whether to
+                  descend into other AST nodes during the search. Higher priority nodes descend
+                  into lower priority. Currently, the only important part of priority is that 
+                  setting a very high priority (e.g. 99) will search every node.
+                
+
+    :Example:
+        If both the student and solution code are.. ::
+
+            SELECT a FROM b; SELECT x FROM y;
+
+        then we can focus on the first select with::
+        
+            # approach 1: with manually created State instance
+            state = State(*args, **kwargs)
+            new_state = check_node(state, 'SelectStmt', 0)
+            
+            # approach 2:  with Ex and chaining
+            new_state = Ex().check_node('SelectStmt', 0)
+
+    """
+    df = partial(state.ast_dispatcher, name, slice(None), priority=priority)
+
+    sol_stmt_list = df(state.solution_ast) 
+    try: sol_stmt = sol_stmt_list[index]
+    except IndexError: raise IndexError("Can't get %s statement at index %s"%(name, index))
+
+    stu_stmt_list = df(state.student_ast)
+    try: stu_stmt = stu_stmt_list[index]
+    except IndexError: 
+        # use speaker on ast dialect module to get message, or fall back to generic
+        _msg = state.ast_dispatcher.describe(sol_stmt, missing_msg, index = index)
+        state.do_test(_msg or MSG_CHECK_FALLBACK)
+
+    action = {'type': 'check_node', 'kwargs': {'name': name, 'index': index}, 'node': stu_stmt}
+    
+    return state.to_child(student_ast = stu_stmt, solution_ast = sol_stmt,
+                          history = state.history + (action,)) 
+
+
+@requires_ast
+def check_field(state, name, index=None, missing_msg="Could not find the {index}{field_name} of the {node_name}."):
+    """Select an attribute from an abstract syntax tree (AST) node, using the attribute name.
+    
+    Args:
+        state: State instance describing student and solution code. Can be omitted if used with Ex().
+        name: the name of the attribute to select from current AST node.
+        index: entry to get from field. If too few entires, will fail with missing_msg.
+        missing_msg: feedback message if attribute is not in student AST.
+
+    :Example:
+        If both the student and solution code are.. ::
+            
+            SELECT a FROM b; SELECT x FROM y;
+
+        then we can get the from_clause using ::
+
+            # approach 1: with manually created State instance -----
+            state = State(*args, **kwargs)
+            select = check_node(state, 'SelectStmt', 0)
+            clause = check_field(select, 'from_clause')
+
+            # approach 2: with Ex and chaining ---------------------
+            select = Ex().check_node('SelectStmt', 0)     # get first select statement
+            clause =  select.check_field('from_clause')    # get from_clause (a list)
+            clause2 = select.check_field('from_clause', 0) # get first entry in from_clause
+    """
+    try: 
+        sol_attr = getattr(state.solution_ast, name)
+        if index is not None: sol_attr = sol_attr[index]
+    except IndexError: 
+        raise IndexError("Can't get %s attribute"%name)
+
+    try: 
+        stu_attr = getattr(state.student_ast, name)
+        if index is not None: stu_attr = stu_attr[index]
+    except: 
+        # use speaker on ast dialect module to get message, or fall back to generic
+        _msg = state.ast_dispatcher.describe(state.student_ast, missing_msg, field = name, index = index)
+        state.do_test(_msg or MSG_CHECK_FALLBACK)
+
+    # fail if attribute exists, but is none only for student
+    if stu_attr is None and sol_attr is not None:
+        _msg = state.ast_dispatcher.describe(state.student_ast, missing_msg, field = name, index = index)
+        state.do_test(_msg)
+
+    action = {'type': 'check_field', 'kwargs': {'name': name, 'index': index}}
+
+    return state.to_child(student_ast = stu_attr, solution_ast = sol_attr,
+                          history = state.history + (action,)) 
+
+import re
+
+def test_student_typed(state, text, msg="Submission does not contain the code `{}`.", fixed=False):
+    """Test whether the student code contains text.
+
+    Args:
+        state: State instance describing student and solution code. Can be omitted if used with Ex().
+        text : text that student code must contain.
+        msg  : feedback message if text is not in student code.
+        fixed: whether to match text exactly, rather than using regular expressions.
+
+    Note:
+        Functions like ``check_node`` focus on certain parts of code.
+        Using these functions followed by ``test_student_typed`` will only look
+        in the code being focused on.
+
+    :Example:
+        If the student code is.. ::
+
+            SELECT a FROM b WHERE id < 100
+
+        Then the first test below would (unfortunately) pass, but the second would fail..::
+
+            # contained in student code
+            Ex().test_student_typed(text="id < 10")
+
+            # the $ means that you are matching the end of a line
+            Ex().test_student_typed(text="id < 10$")
+
+        By setting ``fixed = True``, you can search for fixed strings::
+
+            # without fixed = True, '*' matches any character
+            Ex().test_student_typed(text="SELECT * FROM b")               # passes
+            Ex().test_student_typed(text="SELECT \\\\* FROM b")             # fails
+            Ex().test_student_typed(text="SELECT * FROM b", fixed=True)   # fails
+
+        You can check only the code corresponding to the WHERE clause, using ::
+
+            where = Ex().check_node('SelectStmt', 0).check_field('where_clause')
+            where.test_student_typed(text = "id < 10)
+
+
+    """
+    stu_ast = state.student_ast
+    stu_code = state.student_code
+
+    # fallback on using complete student code if no ast
+    ParseError = state.ast_dispatcher.ParseError
+    stu_text = stu_ast._get_text(stu_code) if not isinstance(stu_ast, ParseError) else stu_code
+
+    _msg = msg.format(text)
+
+    # either simple text matching or regex test
+    res = text in stu_text if fixed else re.search(text, stu_text)
+
+    if not res:
+        state.do_test(_msg)
+
+    return state
+
+
+@requires_ast
+def has_equal_ast(state, 
+                  msg="Check the {ast_path}. Your code does not seem to match the solution.",
+                  sql=None,
+                  start="sql_script",
+                  exact=True):
+    """Test whether the student and solution code have identical AST representations
+
+    Args:
+        state: State instance describing student and solution code. Can be omitted if used with Ex().
+        msg  : feedback message if student and solution ASTs don't match
+        sql  : optional code to use in place of the solution ast
+        start: if sql arg is used, the parser rule to parse the sql code
+        exact: whether to require an exact match (True), or only that the 
+               student AST contains the solution AST.
+
+    :Example:
+        Suppose the student and solution code is `SeLeCt 1` and `SELECT 1`, respectively.
+        In this case, the SCT `Ex().has_equal_ast()` will pass, since both
+        select statements return identical ASTs.
+
+        If the solution code is..::
+
+            SELECT * FROM b WHERE id > 1 AND name = 'filip'
+
+        Then the following SCT makes sure ``id > 1`` was used somewhere in the WHERE clause.::
+
+            
+            Ex().check_node('SelectStmt') \
+                .check_field('where_clause') \
+                .has_equal_ast(sql = 'id > 1', start='expression', exact=False)
+        
+    """
+    ast = state.ast_dispatcher.ast
+    sol_ast = state.solution_ast if sql is None else ast.parse(sql, start)
+
+    stu_rep = repr(state.student_ast)
+    sol_rep = repr(sol_ast)
+
+    _msg = msg.format(ast_path = state.get_ast_path())
+    if       exact and (sol_rep != stu_rep):     state.do_test(_msg or MSG_CHECK_FALLBACK)
+    elif not exact and (sol_rep not in stu_rep): state.do_test(_msg or MSG_CHECK_FALLBACK)
+
+    return state
+
+def verify_ast_parses(state):
+    asts = [state.student_ast, state.solution_ast]
+    if any(isinstance(c, state.ast_dispatcher.ParseError) for c in asts):
+        state.do_test("AST did not parse")
+
+    return state

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -135,6 +135,7 @@ class ExGen:
 
         return Chain(state or self.root_state, attr_scts = self.attr_scts)
 
+Ex = ExGen(None, {})
 
 def create_sct_context(State, sct_dict, root_state = None):
     state_dec = state_dec_gen(State, sct_dict)

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -1,0 +1,105 @@
+from ast import NodeVisitor, AST
+from collections.abc import Sequence
+import inspect
+import importlib
+
+class Selector(NodeVisitor):
+
+    def __init__(self, src, priority = None):
+        self.src = src
+        self.priority = src._priority if priority is None else priority
+        self.out = []
+
+    # TODO: needed to repeat this function, since _fields is more complex on the
+    #       custom ASTs, should simplify _fields, so this can be removed..
+    @staticmethod
+    def iter_fields(node): 
+        return [(k, getattr(node, k)) for k in node._get_field_names() if hasattr(node, k)]
+
+    def generic_visit(self, node):
+        """Called if no explicit visitor function exists for a node."""
+        for field, value in self.iter_fields(node):
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, AST):
+                        self.visit(item)
+            elif isinstance(value, AST):
+                self.visit(value)
+
+    def visit(self, node, head=False):
+        if head: return super().visit(node)
+
+        if self.is_match(node): self.out.append(node)
+        if self.has_priority_over(node):
+            return super().visit(node)
+
+    def visit_list(self, lst):
+        for item in lst: self.visit(item)
+
+    def is_match(self, node):
+        if type(node) is self.src: return True
+        else: return False
+
+    def has_priority_over(self, node):
+        return self.priority > node._priority
+
+
+class Dispatcher:
+    def __init__(self, nodes, ast=None, safe_parsing=True):
+        """Wrapper to instantiate and use a Selector using node names."""
+        self.nodes = nodes
+        self.ast = ast
+        self.safe_parsing = safe_parsing
+
+        self.ParseError = getattr(self.ast, 'ParseError', None) or \
+                          getattr(self.ast, 'AntlrException', None)
+
+    def __call__(self, name, index, node, *args, **kwargs):
+        # TODO: gentle error handling
+        ast_cls = self.nodes[name]
+
+        selector = Selector(ast_cls, *args, **kwargs)
+        selector.visit(node, head=True)
+
+        return selector.out[index]
+
+    def parse(self, code):
+        # AST modules should define exception as ParseError, but use AntlrException
+        # for backwards compatibility
+        try:
+            return self.ast.parse(code, strict=True)
+        except self.ParseError as e:
+            if self.safe_parsing: return e
+            else: raise e
+
+    def describe(self, node, msg, field = "", **kwargs):
+        speaker = getattr(self.ast, 'speaker', None)
+
+        has_index = kwargs.get('index') is not None
+        if has_index: 
+            phrase = "{} entry in the " if field else "{} "
+            kwargs['index'] = phrase.format(get_ord(kwargs['index'] + 1))
+        else: 
+            kwargs['index'] = ""
+
+        if speaker:
+            return self.ast.speaker.describe(node, field = field, 
+                                             fmt = msg, **kwargs)
+
+    @classmethod
+    def from_module(cls, mod):
+        if isinstance(mod, str): mod = importlib.import_module(mod)
+
+        ast_nodes = {k: v for k, v in vars(mod).items() if (inspect.isclass(v) and issubclass(v, mod.AstNode))}
+        dispatcher = cls(ast_nodes, ast=mod)
+        return dispatcher
+
+def get_ord(num):
+    assert num != 0, "use strictly positive numbers in get_ord()"
+    nums = {1: "first", 2: "second", 3:"third", 4:"fourth",
+            5: "fifth", 6: "sixth", 7:"seventh", 8:"eight",
+            9: "ninth", 10: "tenth"}
+    if num in nums:
+        return(nums[num])
+    else:
+        return("%dth" % num)

--- a/protowhat/tests/test_selectors.py
+++ b/protowhat/tests/test_selectors.py
@@ -1,0 +1,15 @@
+from protowhat.selectors import Selector, Dispatcher
+from protowhat.State import State
+import importlib
+from protowhat.Reporter import Reporter
+from protowhat.Test import TestFail as TF
+import pytest
+
+@pytest.mark.xfail
+def test_selector_standalone():
+    from ast import Expr, Num        # use python's builtin ast library
+    Expr._priority = 0; Num._priority = 1
+    node = Expr(value = Num(n = 1))
+    sel = Selector(Num)
+    sel.visit(node)
+    assert isinstance(sel.out[0], Num)

--- a/protowhat/tests/test_utils_ast.py
+++ b/protowhat/tests/test_utils_ast.py
@@ -1,0 +1,40 @@
+import bashlex
+import bashlex.errors
+from protowhat import utils_ast
+
+from collections import OrderedDict
+
+def dump_bash(obj, parent_cls = bashlex.ast.node, v = False):
+    """Takes a bashlex AST and returns it structured as a dictionary.
+
+    Each dictionary entry has two fields:
+        type: the name of the AST node
+        data: a dictionary mapping field_name: attribute node (or list of nodes)
+    
+    """
+    # pull element out of single entry lists
+    if isinstance(obj, (list, tuple)) and len(obj) == 1: obj = obj[0]
+    # dump to dict
+    if isinstance(obj, parent_cls):
+        if obj.kind in ['word', 'reservedword'] and not v:
+            return obj.word
+        fields = OrderedDict()
+        for name in [el for el in obj.__dict__.keys() if el not in ('kind', 'pos')]:
+            attr = getattr(obj, name)
+            if   isinstance(attr, parent_cls): fields[name] = dump_bash(attr, parent_cls, v)
+            elif isinstance(attr, list) and len(attr) == 0: continue
+            elif isinstance(attr, list): fields[name] = [dump_bash(x, parent_cls, v) for x in attr]
+            else: fields[name] = attr
+        return {'type': obj.kind, 'data': fields}
+    elif isinstance(obj, list):
+        return [dump_bash(x, parent_cls, v) for x in obj]
+    else: raise Exception("received non-node object?") 
+
+
+def test_AstModule_load():
+    cmd = """for ii in {1..10}; do echo $ii; done"""
+    ast_mod = utils_ast.AstModule(bashlex.parse, bashlex.errors.ParsingError)
+    data_dict = dump_bash(ast_mod.parse(cmd))
+    tree = ast_mod.load(data_dict)
+
+    assert type(tree.list[0]) == ast_mod.classes['for']

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -24,10 +24,11 @@ class AstNode(AST):
 
 
 class AstModule:
-    def __init__(self, parse, ParseError = Exception, classes = None):
+    def __init__(self, parse, ParseError = Exception, classes = None, AstNode = AstNode):
         self.parse = parse
         self.classes = classes or {}
         self.ParseError = ParseError
+        self.AstNode = AstNode
 
     def load(self, node):
         if not isinstance(node, dict): return node        # return primitives
@@ -47,6 +48,13 @@ class AstModule:
     def _instantiate_node(self, type_str):
         cls = self.classes.get(type_str, None)
         if not cls:
-            cls = self.classes[type_str] = type(type_str, (AstNode,), {})
+            cls = type(type_str, (AstNode,), {})
+            self.classes[type_str] = cls
 
         return cls()
+
+    @classmethod
+    def from_parse_dict(cls, parse):
+        obj = cls(None)
+        obj.parse = lambda cmd, strict: obj.load(parse(cmd, strict))
+        return obj

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -1,0 +1,52 @@
+from ast import AST
+
+class AstNode(AST):
+    _fields = []
+    _priority = 1
+
+    def _get_field_names(self):
+        return self._fields
+    
+    def _get_text(self, text):
+        raise NotImplemented()
+
+    def _get_pos(self):
+        raise NotImplemented()
+
+    def __str__(self):
+        els = [k for k in self._get_field_names() if getattr(self, k, None) is not None]
+        return "{}: {}".format(self.__class__.__name__, ", ".join(els))
+
+    def __repr__(self):
+        field_reps = [(k, repr(getattr(self, k))) for k in self._get_field_names() if getattr(self, k, None) is not None]
+        args = ", ".join("{} = {}".format(k, v) for k, v in field_reps)
+        return "{}({})".format(self.__class__.__name__, args)
+
+
+class AstModule:
+    def __init__(self, parse, ParseError = Exception, classes = None):
+        self.parse = parse
+        self.classes = classes or {}
+        self.ParseError = ParseError
+
+    def load(self, node):
+        if not isinstance(node, dict): return node        # return primitives
+
+        obj = self._instantiate_node(node['type'])
+
+        data = node['data']
+        obj._fields = tuple(data.keys())
+        for field_name, attr in data.items():
+            if isinstance(attr, (list, tuple)): child = [self.load(entry) for entry in attr]
+            else: child = self.load(attr)
+            setattr(obj, field_name, child)
+
+        return obj
+
+
+    def _instantiate_node(self, type_str):
+        cls = self.classes.get(type_str, None)
+        if not cls:
+            cls = self.classes[type_str] = type(type_str, (AstNode,), {})
+
+        return cls()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+bashlex


### PR DESCRIPTION
`selectors.py` is identical to `selectors.py` in the corresponding sqlwhat PR https://github.com/datacamp/sqlwhat/pull/116

(I'll delete the copy of that and `check_funcs.py` in sqlwhat once everything looks good)