### PR TITLE
Fs/test not

### DIFF
--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -164,7 +164,6 @@ def test_student_typed(state, text, msg="Submission does not contain the code `{
             where = Ex().check_node('SelectStmt', 0).check_field('where_clause')
             where.test_student_typed(text = "id < 10)
 
-
     """
     stu_ast = state.student_ast
     stu_code = state.student_code

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -74,7 +74,9 @@ def test_not(state, *args, msg):
             try:
                 state.do_test(closure)
             except TestFail:
-                continue # it fails, as expected
+                # it fails, as expected, so straighten reporter
+                state.reporter.failed_test = False
+                continue
             return state.do_test(msg)
 
     # return original state, so can be chained

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -44,6 +44,42 @@ def multi(state, *args):
     # return original state, so can be chained
     return state
 
+def test_not(state, *args, msg):
+    """Run multiple subtests that should fail. If all subtests fail, returns original state (for chaining)
+
+    Args:
+        state: State instance describing student and solution code. Can be omitted if used with Ex().
+        args: one or more sub-SCTs to run.
+    :Example:
+        Thh SCT below runs two test_student_typed cases.. ::
+
+            Ex().multi(test_student_typed('INNER'), test_student_typed('OUTER'))
+
+        If students use INNER (JOIN) or OUTER (JOIN) in their code, this test will fail.
+
+    Note:
+        This function can be thought as a NOT(x OR y OR ...) statement, since all tests it runs must fail
+        This function can be considered a direct counterpart of multi.
+
+    """
+
+    for arg in args:
+        # when input is a single test, make iterable
+        if callable(arg): arg = [arg]
+
+        for test in arg:
+            # assume test is function needing a state argument
+            # partial state so reporter can test
+            closure = partial(test, state)
+            try:
+                state.do_test(closure)
+            except TestFail:
+                continue # it fails, as expected
+            return state.do_test(msg)
+
+    # return original state, so can be chained
+    return state
+
 def extend(state, *args):
     for arg in args:
         # when input is a single test, make iterable

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -58,8 +58,9 @@ def test_not(state, *args, msg):
         If students use INNER (JOIN) or OUTER (JOIN) in their code, this test will fail.
 
     Note:
-        This function can be thought as a NOT(x OR y OR ...) statement, since all tests it runs must fail
-        This function can be considered a direct counterpart of multi.
+        - This function is currently only tested in working with test_student_typed in the subtests.
+        - This function can be thought as a NOT(x OR y OR ...) statement, since all tests it runs must fail
+        - This function can be considered a direct counterpart of multi.
 
     """
 

--- a/protowhat/tests/test_check_logic.py
+++ b/protowhat/tests/test_check_logic.py
@@ -56,6 +56,27 @@ def test_test_or_pass(state):
 def test_test_or_fail(state):
     with pytest.raises(TF): cl.test_or(state, fails, fails)
 
+def test_test_not_pass(state):
+    cl.test_not(state, fails, msg='fail')
+
+def test_test_not_pass_2(state):
+    cl.test_not(state, [fails, fails], msg='fail')
+
+def test_test_not_fail(state):
+    with pytest.raises(TF):
+        cl.test_not(state, passes, msg='fail')
+        assert state.reporter.feedback.message == 'fail'
+
+def test_test_not_fail_2(state):
+    with pytest.raises(TF):
+        cl.test_not(state, [passes, fails], msg='fail')
+        assert state.reporter.feedback.message == 'fail'
+
+def test_test_not_fail_3(state):
+    with pytest.raises(TF):
+        cl.test_not(state, [fails, passes], msg='fail')
+        assert state.reporter.feedback.message == 'fail'
+
 def test_test_correct_pass(state):
     cl.test_correct(state, passes, fails)
 

--- a/protowhat/tests/test_check_logic.py
+++ b/protowhat/tests/test_check_logic.py
@@ -17,6 +17,7 @@ def state():
         student_conn = None, solution_conn = None)
 
 def fails(state, msg=""): 
+    state.reporter.failed_test = True
     state.reporter.feedback.msg = msg
     raise TF
 
@@ -58,9 +59,11 @@ def test_test_or_fail(state):
 
 def test_test_not_pass(state):
     cl.test_not(state, fails, msg='fail')
+    assert not state.reporter.failed_test
 
 def test_test_not_pass_2(state):
     cl.test_not(state, [fails, fails], msg='fail')
+    assert not state.reporter.failed_test
 
 def test_test_not_fail(state):
     with pytest.raises(TF):


### PR DESCRIPTION
Related to

- https://github.com/datacamp/sqlwhat/issues/97
- https://github.com/datacamp/sqlwhat/pull/120
- https://github.com/datacamp/courses-msft-transact-sql/compare/fs/test-not

Notes:
- The [implementation that is in pythonwhat](https://github.com/datacamp/pythonwhat/blob/master/pythonwhat/check_funcs.py#L168-L178) is not correct. This will pass even if one of the subtests passes, while it should only pass when all subtests fail.
- I had to duplicate some of the code that is in `multi()`, but couldn't quite figure out which pattern to use (partials?) to make it dry. Open to suggestions!
