### PR TITLE
Ast refactor

### DIFF
--- a/example/example_helper.py
+++ b/example/example_helper.py
@@ -3,19 +3,18 @@ import inspect
 import asttokens
 
 class PythonAst:
-    def _get_text(self, code):
+    def get_text(self, code):
         atok = asttokens.ASTTokens(code, tree = self)
         return atok.get_text(self)
 
 def patch_ast():
     # forces class to use PythonAst as a mixin
-    # allows them to use _get_text method
+    # allows them to use get_text method
     for obj in ast.__dict__.values():
         if inspect.isclass(obj) and issubclass(obj, ast.AST):
             if obj == ast.AST or PythonAst in obj.__bases__: continue
             obj.__bases__ = obj.__bases__ + (PythonAst, )
             obj._priority = 0
-            obj._get_field_names = lambda self: self._fields
 
     # add AstNode, and ParseError classes for Dispatcher
     ast.AstNode = PythonAst

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -6,7 +6,7 @@ class Feedback(object):
     def get_line_info(self):
         try:
             if self.astobj is not None:
-                return self.astobj._get_pos()
+                return self.astobj.get_position()
             else:
                 return {}
         except:

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -12,10 +12,9 @@ def requires_ast(f):
 
         # fail if no ast parser in use
         if any(ast is None for ast in state_ast):
-            pass
-            # raise TypeError(
-            #     "Trying to use ast, but it is None. Are you using a parser?"
-            # )
+            raise TypeError(
+                "Trying to use ast, but it is None. Are you using a parser? {} {}".format(args, kwargs)
+            )
 
         # check whether the parser passed or failed for some code
         ParseError = state.ast_dispatcher.ParseError

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -101,7 +101,7 @@ def check_node(
 def check_edge(
     state,
     name,
-    index=None,
+    index=0,
     missing_msg="Check the {ast_path}. Could not find the {index}{field_name}.",
 ):
     """Select an attribute from an abstract syntax tree (AST) node, using the attribute name.
@@ -109,7 +109,7 @@ def check_edge(
     Args:
         state: State instance describing student and solution code. Can be omitted if used with Ex().
         name: the name of the attribute to select from current AST node.
-        index: entry to get from field. If too few entires, will fail with missing_msg.
+        index: entry to get from a list field. If too few entires, will fail with missing_msg.
         missing_msg: feedback message if attribute is not in student AST.
 
     :Example:
@@ -125,15 +125,13 @@ def check_edge(
             clause = check_edge(select, 'from_clause')
 
             # approach 2: with Ex and chaining ---------------------
-            select = Ex().check_node('SelectStmt', 0)     # get first select statement
-            clause =  select.check_edge('from_clause')    # get from_clause (a list)
-            clause2 = select.check_edge('from_clause', 0) # get first entry in from_clause
+            select = Ex().check_node('SelectStmt', 0)           # get first select statement
+            clause =  select.check_edge('from_clause', None)    # get from_clause (a list)
+            clause2 = select.check_edge('from_clause', 0)       # get first entry in from_clause
     """
     try:
         sol_attr = getattr(state.solution_ast, name)
-        if sol_attr and isinstance(sol_attr, list) and index is None:
-            index = 0
-        if index is not None:
+        if sol_attr and isinstance(sol_attr, list) and index is not None:
             sol_attr = sol_attr[index]
     except IndexError:
         raise IndexError("Can't get %s attribute" % name)
@@ -148,7 +146,7 @@ def check_edge(
 
     try:
         stu_attr = getattr(state.student_ast, name)
-        if index is not None:
+        if stu_attr and isinstance(stu_attr, list) and index is not None:
             stu_attr = stu_attr[index]
     except:
         state.do_test(_msg)

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -222,7 +222,7 @@ def has_code(
         if isinstance(ast, ParseError):
             return code
         try:
-            return ast._get_text(code)
+            return ast.get_text(code)
         except:
             return code
 
@@ -300,7 +300,7 @@ def has_equal_ast(
         if isinstance(ast, str):
             return ast
         try:
-            return ast._get_text(code)
+            return ast.get_text(code)
         except:
             return None
 

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -12,9 +12,10 @@ def requires_ast(f):
 
         # fail if no ast parser in use
         if any(ast is None for ast in state_ast):
-            raise TypeError(
-                "Trying to use ast, but it is None. Are you using a parser?"
-            )
+            pass
+            # raise TypeError(
+            #     "Trying to use ast, but it is None. Are you using a parser?"
+            # )
 
         # check whether the parser passed or failed for some code
         ParseError = state.ast_dispatcher.ParseError

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -131,6 +131,8 @@ def check_edge(
     """
     try:
         sol_attr = getattr(state.solution_ast, name)
+        if sol_attr and isinstance(sol_attr, list) and index is None:
+            index = 0
         if index is not None:
             sol_attr = sol_attr[index]
     except IndexError:

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -5,23 +5,20 @@ class AstNode(AST):
     _fields = []
     _priority = 1
 
-    def _get_field_names(self):
-        return self._fields
-
     def _get_text(self, text):
         raise NotImplemented()
 
-    def _get_pos(self):
+    def get_position(self):
         raise NotImplemented()
 
     def __str__(self):
-        els = [k for k in self._get_field_names() if getattr(self, k, None) is not None]
+        els = [k for k in self._fields if getattr(self, k, None) is not None]
         return "{}: {}".format(self.__class__.__name__, ", ".join(els))
 
     def __repr__(self):
         field_reps = [
             (k, repr(getattr(self, k)))
-            for k in self._get_field_names()
+            for k in self._fields
             if getattr(self, k, None) is not None
         ]
         args = ", ".join("{} = {}".format(k, v) for k, v in field_reps)

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -29,6 +29,7 @@ class AstNode(AST):
 
 
 class AstModule:
+    # TODO: split parse and dump
     def __init__(self, parse=None, ParseError=Exception, classes=None, AstNode=AstNode):
         if parse:
             self.parse = parse
@@ -59,6 +60,7 @@ class AstModule:
         return obj
 
     def _instantiate_node(self, type_str):
+        # TODO: implement on AstNode (+ interface to get classes)
         cls = self.classes.get(type_str, None)
         if not cls:
             cls = type(type_str, (AstNode,), {})
@@ -68,6 +70,7 @@ class AstModule:
 
     @classmethod
     def from_parse_dict(cls, parse):
+        # TODO: not used?
         obj = cls(None)
         obj.parse = lambda cmd, strict: obj.load(parse(cmd, strict))
         return obj

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -5,7 +5,7 @@ class AstNode(AST):
     _fields = []
     _priority = 1
 
-    def _get_text(self, text):
+    def get_text(self, text):
         raise NotImplemented()
 
     def get_position(self):

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -38,7 +38,7 @@ def state():
         pre_exercise_code = "NA",
         student_result = "", solution_result = "",
         student_conn = None, solution_conn = None,
-        ast_dispatcher = Dispatcher(DUMMY_NODES, ParseHey())
+        ast_dispatcher = Dispatcher(ast.AST, DUMMY_NODES, ParseHey())
         )
 
 def test_initial_state():
@@ -46,7 +46,7 @@ def test_initial_state():
           reporter = Reporter(), pre_exercise_code = "",
           student_result = "", solution_result = "",
           student_conn = None, solution_conn = None,
-          ast_dispatcher = Dispatcher(DUMMY_NODES, ParseHey()))
+          ast_dispatcher = Dispatcher(ast.AST, DUMMY_NODES, ParseHey()))
 
 def test_check_file_use_fs(state, tf):
     state.solution_code = { tf.name: '3 + 3' }
@@ -84,7 +84,7 @@ def code_state():
         pre_exercise_code = "NA",
         student_result = "", solution_result = "",
         student_conn = None, solution_conn = None,
-        ast_dispatcher = Dispatcher(DUMMY_NODES, ParseHey())
+        ast_dispatcher = Dispatcher(ast.AST, DUMMY_NODES, ParseHey())
         )
 
 def test_check_file(code_state):

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -11,8 +11,6 @@ from protowhat.checks.check_funcs import check_node
 # TODO: selectors require a _priority attribute and _get_field_names
 #       this is a holdover from the sql ast modules
 ast.Expr._priority = 0
-ast.Module._get_field_names = lambda self: self._fields
-ast.Expr._get_field_names = lambda self: self._fields
 DUMMY_NODES = {'Expr': ast.Expr}
 
 class ParseHey:
@@ -37,7 +35,7 @@ def state():
         solution_code = "",
         reporter = Reporter(),
         # args below should be ignored
-        pre_exercise_code = "NA", 
+        pre_exercise_code = "NA",
         student_result = "", solution_result = "",
         student_conn = None, solution_conn = None,
         ast_dispatcher = Dispatcher(DUMMY_NODES, ParseHey())
@@ -83,7 +81,7 @@ def code_state():
         solution_code = {'script1.py': '3 + 3', 'script2.py': '4 + 4'},
         reporter = Reporter(),
         # args below should be ignored
-        pre_exercise_code = "NA", 
+        pre_exercise_code = "NA",
         student_result = "", solution_result = "",
         student_conn = None, solution_conn = None,
         ast_dispatcher = Dispatcher(DUMMY_NODES, ParseHey())


### PR DESCRIPTION
Update to work with new parsing libraries

- support dynamic nodes
- change check_edge default argument

Changed default would best be temporary until SCTs are fixed.
The new way to get the old behaviour will still work when reverting the argument default change (and then those SCTs can be updated to).