### PR TITLE
Make protowhat the base for pythonwhat

### DIFF
--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -1,0 +1,24 @@
+class Feedback:
+    def __init__(self, message, astobj=None):
+        self.message = message
+        self.astobj = astobj
+
+    def get_line_info(self):
+        try:
+            if self.astobj is not None:
+                return self.astobj.get_position()
+            else:
+                return {}
+        except:
+            return {}
+
+    def get_formatted_line_info(self):
+        formatted_info = self.get_line_info()
+        for k in ["column_start", "column_end"]:
+            if k in formatted_info:
+                formatted_info[k] += 1
+        return formatted_info
+
+
+class InstructorError(Exception):
+    pass

--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -1,16 +1,24 @@
 class Feedback:
-    def __init__(self, message, astobj=None):
+    def __init__(self, message, state=None):
         self.message = message
-        self.highlight = astobj
+        self.highlight = None
+        self.highlighting_disabled = False
+        if state is not None:
+            self.highlight = getattr(state, "highlight", None)
+            self.highlighting_disabled = state.highlighting_disabled
+
+    def _line_info(self):
+        return self.highlight.get_position()
 
     def get_line_info(self):
+        result = None
         try:
-            if self.highlight is not None:
-                return self.highlight.get_position()
-            else:
-                return {}
+            if self.highlight is not None and not self.highlighting_disabled:
+                result = self._line_info()
         except:
-            return {}
+            pass
+
+        return result or {}
 
     def get_formatted_line_info(self):
         formatted_info = self.get_line_info()

--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -1,12 +1,12 @@
 class Feedback:
     def __init__(self, message, astobj=None):
         self.message = message
-        self.astobj = astobj
+        self.highlight = astobj
 
     def get_line_info(self):
         try:
-            if self.astobj is not None:
-                return self.astobj.get_position()
+            if self.highlight is not None:
+                return self.highlight.get_position()
             else:
                 return {}
         except:

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -51,7 +51,7 @@ class Reporter:
 
     def build_final_payload(self):
         if self.errors and not self.errors_allowed:
-            feedback_msg = "Have a look at the console: your code contains an error. Fix it and try again!"
+            feedback_msg = "Your code generated an error. Fix it and try again!"
             return {"correct": False, "message": Reporter.to_html(feedback_msg)}
         else:
             return {"correct": True, "message": Reporter.to_html(self.success_msg)}

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -3,7 +3,7 @@ import inspect
 from jinja2 import Template
 
 from protowhat.Feedback import Feedback
-from protowhat.Test import Fail
+from protowhat.Test import Fail, Test
 
 
 class DummyParser:
@@ -85,16 +85,15 @@ class State:
         except StopIteration:
             return self.ast_dispatcher.describe(self.student_ast, "{node_name}")
 
-    def do_test(self, feedback_msg, highlight=None):
-        # TODO: rename to `raise`
-        highlight = self.student_ast if highlight is None else highlight
-        feedback = Feedback(feedback_msg, highlight)
+    def report(self, feedback: Feedback):
+        # TODO
+        if feedback.highlight is None:
+            feedback.highlight = self.student_ast
         test = Fail(feedback)
 
-        return self.run_test(test)
+        return self.do_test(test)
 
-    def run_test(self, test):
-        # TODO: rename to `do_test`
+    def do_test(self, test: Test):
         return self.reporter.do_test(test)
 
     def to_child(self, append_message="", **kwargs):

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -64,7 +64,7 @@ class State:
                 result = self.ast_dispatcher.parse(text)
             except self.ast_dispatcher.ParseError as e:
                 if test:
-                    raise e  # todo: self.do_test(Fail(Feedback(e.message)))
+                    raise e  # todo: self.report(Feedback(e.message))
                 else:
                     raise InstructorError(
                         "Something went wrong when parsing PEC or solution code: %s"
@@ -104,8 +104,7 @@ class State:
             return self.ast_dispatcher.describe(self.student_ast, "{node_name}")
 
     def report(self, feedback: Feedback):
-        # TODO
-        if feedback.highlight is None:
+        if feedback.highlight is None and self is not getattr(self, "root_state", None):
             feedback.highlight = self.student_ast
         test = Fail(feedback)
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -154,6 +154,7 @@ class State:
             # don't bother appending if there is no message
             if not d or not d["msg"]:
                 continue
+            # TODO: rendering is slow in tests (40% of test time)
             out = Template(d["msg"].replace("__JINJA__:", "")).render(tmp_kwargs)
             out_list.append(out)
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -2,6 +2,9 @@ from copy import copy
 import inspect
 from jinja2 import Template
 
+from protowhat.Feedback import Feedback
+from protowhat.Test import Fail
+
 
 class DummyParser:
     def __init__(self):
@@ -82,10 +85,17 @@ class State:
         except StopIteration:
             return self.ast_dispatcher.describe(self.student_ast, "{node_name}")
 
-    def do_test(self, *args, highlight=None, **kwargs):
+    def do_test(self, feedback_msg, highlight=None):
+        # TODO: rename to `raise`
         highlight = self.student_ast if highlight is None else highlight
+        feedback = Feedback(feedback_msg, highlight)
+        test = Fail(feedback)
 
-        return self.reporter.do_test(*args, highlight=highlight, **kwargs)
+        return self.run_test(test)
+
+    def run_test(self, test):
+        # TODO: rename to `do_test`
+        return self.reporter.do_test(test)
 
     def to_child(self, append_message="", **kwargs):
         """Basic implementation of returning a child state"""

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -31,6 +31,7 @@ class State:
         solution_result,
         reporter,
         force_diagnose=False,
+        highlighting_disabled=False,
         solution_ast=None,
         student_ast=None,
         fname=None,

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -55,8 +55,7 @@ class Test:
         """
         Perform the actual test. For the standard test, result will be set to False.
         """
-        # TODO raise NotImplementedError (use Fail)
-        self.result = False
+        raise NotImplementedError
 
     def get_feedback(self):
         return self.feedback

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -1,16 +1,5 @@
-class Feedback(object):
-    def __init__(self, message, astobj=None):
-        self.message = message
-        self.astobj = astobj
-
-    def get_line_info(self):
-        try:
-            if self.astobj is not None:
-                return self.astobj.get_position()
-            else:
-                return {}
-        except:
-            return {}
+from protowhat.Feedback import Feedback
+import numpy as np
 
 
 class TestFail(Exception):
@@ -18,3 +7,61 @@ class TestFail(Exception):
         super().__init__(feedback.message)
         self.feedback = feedback
         self.payload = payload
+
+
+class Test:
+    """
+    The basic Test. It should only contain a failure message, as all tests should result in
+    a failure message when they fail.
+
+    Note:
+        This test should not be used by itself, subclasses should be used.
+
+    Attributes:
+        feedback (str): A string containing the failure message in case the test fails.
+        result (bool): True if the test succeed, False if it failed. None if it hasn't been tested yet.
+    """
+
+    def __init__(self, feedback):
+        """
+        Initialize the standard test.
+
+        Args:
+            feedback: string or Feedback object
+        """
+        if issubclass(type(feedback), Feedback):
+            self.feedback = feedback
+        elif issubclass(type(feedback), str):
+            self.feedback = Feedback(feedback)
+        else:
+            raise TypeError(
+                "When creating a test, specify either a string or a Feedback object"
+            )
+
+        self.result = None
+
+    def test(self):
+        """
+        Wrapper around specific tests. Tests only get one chance.
+        """
+        if self.result is None:
+            try:
+                self.specific_test()
+                self.result = np.array(self.result).all()
+            except:
+                self.result = False
+
+    def specific_test(self):
+        """
+        Perform the actual test. For the standard test, result will be set to False.
+        """
+        # TODO raise NotImplementedError (use Fail)
+        self.result = False
+
+    def get_feedback(self):
+        return self.feedback
+
+
+class Fail(Test):
+    def specific_test(self):
+        self.result = False

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from collections.abc import Mapping
 
+from protowhat.Feedback import Feedback
+
 
 def check_file(
     state,
@@ -19,16 +21,16 @@ def check_file(
     if use_fs:
         p = Path(fname)
         if not p.exists():
-            state.do_test(missing_msg.format(fname))  # test file exists
+            state.report(Feedback(missing_msg.format(fname)))  # test file exists
         if p.is_dir():
-            state.do_test(is_dir_msg.format(fname))  # test its not a dir
+            state.report(Feedback(is_dir_msg.format(fname)))  # test its not a dir
 
         code = p.read_text()
     else:
         code = _get_fname(state, "student_code", fname)
 
         if code is None:
-            state.do_test(missing_msg.format(fname))  # test file exists
+            state.report(Feedback(missing_msg.format(fname)))  # test file exists
 
     sol_kwargs = {"solution_code": None, "solution_ast": None}
     if use_solution:
@@ -61,7 +63,6 @@ def _get_fname(state, attr, fname):
 def has_dir(state, fname, incorrect_msg="Did you create a directory named `{}`?"):
     """Test whether a directory exists."""
     if not Path(fname).is_dir():
-        state.do_test(incorrect_msg.format(fname))
+        state.report(Feedback(incorrect_msg.format(fname)))
 
     return state
-

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -64,6 +64,6 @@ def _get_fname(state, attr, fname):
 def has_dir(state, fname, incorrect_msg="Did you create a directory named `{}`?"):
     """Test whether a directory exists."""
     if not Path(fname).is_dir():
-        state.do_test(Fail(Feedback(incorrect_msg.format(fname))))
+        state.report(Feedback(incorrect_msg.format(fname)))
 
     return state

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from collections.abc import Mapping
 
 from protowhat.Feedback import Feedback
+from protowhat.Test import Fail
 
 
 def check_file(
@@ -39,12 +40,12 @@ def check_file(
             raise Exception("Solution code does not have file named: %s" % fname)
         sol_kwargs["solution_code"] = sol_code
         sol_kwargs["solution_ast"] = (
-            state.ast_dispatcher.parse(sol_code) if parse else None
+            state.parse(sol_code, test=False) if parse else None
         )
 
     return state.to_child(
         student_code=code,
-        student_ast=state.ast_dispatcher.parse(code) if parse else None,
+        student_ast=state.parse(code) if parse else None,
         fname=fname,
         **sol_kwargs
     )
@@ -63,6 +64,6 @@ def _get_fname(state, attr, fname):
 def has_dir(state, fname, incorrect_msg="Did you create a directory named `{}`?"):
     """Test whether a directory exists."""
     if not Path(fname).is_dir():
-        state.report(Feedback(incorrect_msg.format(fname)))
+        state.do_test(Fail(Feedback(incorrect_msg.format(fname))))
 
     return state

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from collections.abc import Mapping
 
 from protowhat.Feedback import Feedback
-from protowhat.Test import Fail
 
 
 def check_file(

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -1,5 +1,4 @@
 from functools import partial, wraps
-import copy
 
 from protowhat.Feedback import Feedback
 

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -69,7 +69,7 @@ def check_node(
             new_state = Ex().check_node('SelectStmt', 0)
 
     """
-    df = partial(state.ast_dispatcher, name, slice(None), priority=priority)
+    df = partial(state.ast_dispatcher, name, priority=priority)
 
     sol_stmt_list = df(state.solution_ast)
     try:

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -21,6 +21,7 @@ def requires_ast(f):
             )
 
         # check whether the parser passed or failed for some code
+        # if safe_parsing is enabled in the Dispatcher (otherwise an exception would be raised earlier)
         ParseError = state.ast_dispatcher.ParseError
 
         parse_fail = any(isinstance(ast, ParseError) for ast in state_ast)
@@ -285,7 +286,7 @@ def has_equal_ast(
                 .has_equal_ast(sql = 'id > 1')
 
     """
-    ast = state.ast_dispatcher.ast
+    ast = state.ast_dispatcher.ast_mod
     sol_ast = state.solution_ast if sql is None else ast.parse(sql, start)
 
     # if sql is set, exact defaults to False.

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -3,13 +3,6 @@ from protowhat.Test import TestFail, Fail
 from functools import partial
 
 
-def fail(state, incorrect_msg="fail"):
-    """Always fails the SCT, with an optional msg."""
-    state.report(Feedback(incorrect_msg))
-
-    return state
-
-
 def multi(state, *tests):
     """Run multiple subtests. Return original state (for chaining).
 
@@ -176,8 +169,8 @@ def disable_highlighting(state):
     return state.to_child(highlighting_disabled=True)
 
 
-def fail(state, msg=""):
-    """Fail SCT
+def fail(state, msg="fail"):
+    """Always fails the SCT, with an optional msg.
 
     This function takes a single argument, ``msg``, that is the feedback given to the student.
     Note that this would be a terrible idea for grading submissions, but may be useful while writing SCTs.
@@ -185,3 +178,5 @@ def fail(state, msg=""):
     """
     _msg = state.build_message(msg)
     state.report(Feedback(_msg, state))
+
+    return state

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -111,7 +111,6 @@ def check_or(state, *tests):
                 check_edge('limit_clause')
             )
     """
-
     success = False
     first_feedback = None
 

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -166,3 +166,22 @@ def iter_tests(tests):
 
         for test in arg:
             yield test
+
+
+def disable_highlighting(state):
+    """Disable highlighting in the remainder of the SCT chain.
+
+    Include this function if you want to avoid that pythonwhat marks which part of the student submission is incorrect.
+    """
+    return state.to_child(highlighting_disabled=True)
+
+
+def fail(state, msg=""):
+    """Fail SCT
+
+    This function takes a single argument, ``msg``, that is the feedback given to the student.
+    Note that this would be a terrible idea for grading submissions, but may be useful while writing SCTs.
+    For example, failing a test will highlight the code as if the previous test/check had failed.
+    """
+    _msg = state.build_message(msg)
+    state.do_test(Fail(Feedback(_msg, state)))

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -2,6 +2,8 @@ from protowhat.Feedback import Feedback
 from protowhat.Test import TestFail, Fail
 from functools import partial
 
+from protowhat.utils import legacy_signature
+
 
 def multi(state, *tests):
     """Run multiple subtests. Return original state (for chaining).
@@ -34,6 +36,7 @@ def multi(state, *tests):
     return state
 
 
+@legacy_signature(incorrect_msg='msg')
 def check_not(state, *tests, msg):
     """Run multiple subtests that should fail. If all subtests fail, returns original state (for chaining)
 

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -5,7 +5,7 @@ from functools import partial
 
 def fail(state, incorrect_msg="fail"):
     """Always fails the SCT, with an optional msg."""
-    state.do_test(Fail(Feedback(incorrect_msg)))
+    state.report(Feedback(incorrect_msg))
 
     return state
 
@@ -72,7 +72,7 @@ def check_not(state, *tests, msg):
         except TestFail:
             # it fails, as expected, off to next one
             continue
-        return state.do_test(Fail(Feedback(msg)))
+        return state.report(Feedback(msg))
 
     # return original state, so can be chained
     return state
@@ -115,7 +115,7 @@ def check_or(state, *tests):
         if success:
             return state  # todo: add test
 
-    state.do_test(Fail(first_feedback))
+    state.report(first_feedback)
 
 
 def check_correct(state, check, diagnose):
@@ -150,7 +150,7 @@ def check_correct(state, check, diagnose):
             feedback = e.feedback
 
     if feedback is not None:
-        state.do_test(Fail(feedback))
+        state.report(feedback)
 
     return state  # todo: add test
 
@@ -184,4 +184,4 @@ def fail(state, msg=""):
     For example, failing a test will highlight the code as if the previous test/check had failed.
     """
     _msg = state.build_message(msg)
-    state.do_test(Fail(Feedback(_msg, state)))
+    state.report(Feedback(_msg, state))

--- a/protowhat/checks/check_simple.py
+++ b/protowhat/checks/check_simple.py
@@ -1,3 +1,6 @@
+from protowhat.Feedback import Feedback
+
+
 def has_chosen(state, correct, msgs):
     """Verify exercises of the type MultipleChoiceExercise
 
@@ -17,7 +20,7 @@ def has_chosen(state, correct, msgs):
     exec(state.student_code, globals(), ctxt)
     sel_indx = ctxt["selected_option"]
     if sel_indx != correct:
-        state.do_test(msgs[sel_indx - 1])
+        state.report(Feedback(msgs[sel_indx - 1]))
     else:
         state.reporter.success_msg = msgs[correct - 1]
 
@@ -41,4 +44,3 @@ def success_msg(state, msg):
     state.reporter.success_msg = msg
 
     return state
-

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -33,7 +33,10 @@ class Chain:
         )
 
     def __getattr__(self, attr):
-        attr_scts = self.__getattribute__("_attr_scts")
+        # Enable fast attribute access
+        if attr == "_attr_scts":
+            raise AttributeError("Prevent getattr recursion on copy")
+        attr_scts = self._attr_scts
         if attr not in attr_scts:
             raise AttributeError("No SCT named %s" % attr)
         elif self._waiting_on_call:

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -52,13 +52,13 @@ class Chain:
     def __rshift__(self, f):
         if self._waiting_on_call:
             self._double_attr_error()
-        elif type(f) == Chain:
+        elif isinstance(f, Chain) and not isinstance(f, F):
             raise BaseException(
-                "did you use a result of the Ex() function on the right hand side of the + operator?"
+                "did you use a result of the Ex() function on the right hand side of the >> operator?"
             )
         elif not callable(f):
             raise BaseException(
-                "right hand side of + operator should be an SCT, so must be callable!"
+                "right hand side of >> operator should be an SCT, so must be callable!"
             )
         else:
             chain = self._sct_copy(f)
@@ -82,14 +82,14 @@ class F(Chain):
         if not self._crnt_sct:
             state = kwargs.get("state") or args[0]
             return reduce(
-                lambda s, cd: self._call_from_data(*cd, state=s), self._stack, state
+                lambda s, cd: self._call_from_data(s, *cd), self._stack, state
             )
         else:
             call_data = (self._crnt_sct, args, kwargs)
             return self.__class__(self._stack + [call_data], self._attr_scts)
 
     @staticmethod
-    def _call_from_data(f, args, kwargs, state):
+    def _call_from_data(state, f, args, kwargs):
         return f(state, *args, **kwargs)
 
     @classmethod

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -50,7 +50,7 @@ class Dispatcher:
         self.ast = ast
         self.safe_parsing = safe_parsing
 
-        self.ParseError = getattr(self.ast, "ParseError", None)
+        self.ParseError = getattr(self.ast, "ParseError", type("ParseError", (Exception,), {}))
 
     def __call__(self, name, node, *args, **kwargs):
         if name in self.nodes:

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -52,7 +52,7 @@ class Dispatcher:
 
         self.ParseError = getattr(self.ast, "ParseError", None)
 
-    def __call__(self, name, index, node, *args, **kwargs):
+    def __call__(self, name, node, *args, **kwargs):
         if name in self.nodes:
             ast_cls = self.nodes[name]
             strict_selector = True
@@ -65,7 +65,7 @@ class Dispatcher:
         )
         selector.visit(node, head=True)
 
-        return selector.out[index]
+        return selector.out
 
     def parse(self, code):
         try:

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -1,0 +1,28 @@
+from functools import wraps
+
+
+def legacy_signature(**kwargs_mapping):
+    """
+    This decorator makes it possible to call a function using old argument names
+    when they are passed as keyword arguments.
+
+    @legacy_signature(old_arg1='arg1', old_arg2='arg2')
+    def func(arg1, arg2=1):
+        return arg1 + arg2
+
+    func(old_arg1=1) == 2
+    func(old_arg1=1, old_arg2=2) == 3
+    """
+
+    def signature_decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            redirected_kwargs = {
+                kwargs_mapping[k] if k in kwargs_mapping else k: v
+                for k, v in kwargs.items()
+            }
+            return f(*args, **redirected_kwargs)
+
+        return wrapper
+
+    return signature_decorator

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -1,4 +1,51 @@
 from ast import AST
+from collections import OrderedDict
+
+
+class DumpConfig:
+    def __init__(
+        self,
+        is_node=lambda node: isinstance(node, AST),
+        node_type=lambda node: node.__class__.__name__,
+        fields_iter=lambda node: node._fields,
+        field_val=lambda node, field: getattr(node, field, None),
+        is_list=lambda node: isinstance(node, list),
+        list_iter=id,
+        leaf_val=id,
+    ):
+        """
+        Configuration to convert a node tree to the dump format
+
+        The default configuration can be used to dump a tree of AstNodes
+        """
+        self.is_node = is_node
+        self.node_type = node_type
+        self.fields_iter = fields_iter
+        self.field_val = field_val
+        self.is_list = is_list
+        self.list_iter = list_iter
+        self.leaf_val = leaf_val
+
+
+def dump(node, config):
+    """
+    Convert a node tree to a simple nested dict
+
+    All steps in this conversion are configurable using DumpConfig
+
+    dump dictionary node: {"type": str, "data": dict}
+    """
+    if config.is_node(node):
+        fields = OrderedDict()
+        for name in config.fields_iter(node):
+            attr = config.field_val(node, name)
+            if attr is not None:
+                fields[name] = dump(attr, config)
+        return {"type": config.node_type(node), "data": fields}
+    elif config.is_list(node):
+        return [dump(x, config) for x in config.list_iter(node)]
+    else:
+        return config.leaf_val(node)
 
 
 class AstNode(AST):
@@ -40,6 +87,10 @@ class AstModule:
     @classmethod
     def parse(cls, code, **kwargs):
         raise NotImplementedError("This method needs to be defined in a subclass.")
+
+    @classmethod
+    def dump(cls, tree):
+        return dump(tree, DumpConfig())
 
     # methods below are for updating an AstModule subclass based on data in the dump dictionary format --
 

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -2,14 +2,14 @@ from ast import AST
 
 
 class AstNode(AST):
-    _fields = []
+    _fields = ()
     _priority = 1
 
     def get_text(self, text):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def get_position(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __str__(self):
         els = [k for k in self._fields if getattr(self, k, None) is not None]
@@ -25,49 +25,47 @@ class AstNode(AST):
         return "{}({})".format(self.__class__.__name__, args)
 
 
+class ParseError(Exception):
+    pass
+
+
 class AstModule:
-    # TODO: split parse and dump
-    def __init__(self, parse=None, ParseError=Exception, classes=None, AstNode=AstNode):
-        if parse:
-            self.parse = parse
-        self.classes = classes or {}
-        self.ParseError = ParseError
-        self.AstNode = AstNode
+    """Subclasses can be used to instantiate a Dispatcher"""
 
-    def parse(self, code, strict):
-        raise NotImplemented("This method needs to be defined in subclass.")
+    AstNode = AstNode
+    ParseError = ParseError
+    nodes = dict()
+    speaker = None
 
-    # methods below are for creating an AstModule instance from a dictionary --
+    @classmethod
+    def parse(cls, code, **kwargs):
+        raise NotImplementedError("This method needs to be defined in a subclass.")
 
-    def load(self, node):
+    # methods below are for updating an AstModule subclass based on data in the dump dictionary format --
+
+    @classmethod
+    def load(cls, node):
         if not isinstance(node, dict):
             return node  # return primitives
 
-        obj = self._instantiate_node(node["type"])
-
+        type_str = node["type"]
         data = node["data"]
-        obj._fields = tuple(data.keys())
-        for field_name, attr in data.items():
-            if isinstance(attr, (list, tuple)):
-                child = [self.load(entry) for entry in attr]
+        obj = cls._instantiate_node(type_str, tuple(data.keys()))
+        for field_name, value in data.items():
+            if isinstance(value, (list, tuple)):
+                child = [cls.load(entry) for entry in value]
             else:
-                child = self.load(attr)
+                child = cls.load(value)
             setattr(obj, field_name, child)
 
         return obj
 
-    def _instantiate_node(self, type_str):
-        # TODO: implement on AstNode (+ interface to get classes)
-        cls = self.classes.get(type_str, None)
-        if not cls:
-            cls = type(type_str, (AstNode,), {})
-            self.classes[type_str] = cls
-
-        return cls()
-
     @classmethod
-    def from_parse_dict(cls, parse):
-        # TODO: not used?
-        obj = cls(None)
-        obj.parse = lambda cmd, strict: obj.load(parse(cmd, strict))
-        return obj
+    def _instantiate_node(cls, type_str, fields):
+        # TODO: implement on AstNode (+ interface to get classes)
+        node_cls = cls.nodes.get(type_str, None)
+        if not node_cls:
+            node_cls = type(type_str, (cls.AstNode,), {"_fields": fields})
+            cls.nodes[type_str] = node_cls
+
+        return node_cls()

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -11,91 +11,115 @@ from protowhat.checks.check_funcs import check_node
 # TODO: selectors require a _priority attribute and _get_field_names
 #       this is a holdover from the sql ast modules
 ast.Expr._priority = 0
-DUMMY_NODES = {'Expr': ast.Expr}
+DUMMY_NODES = {"Expr": ast.Expr}
+
 
 class ParseHey:
     ParseError = SyntaxError
 
-    def parse(self, code, *args, **kwargs): return ast.parse(code)
+    def parse(self, code, *args, **kwargs):
+        return ast.parse(code)
+
 
 def assert_equal_ast(a, b):
     assert ast.dump(a) == ast.dump(b)
 
+
 @pytest.fixture(scope="function")
 def tf():
     with NamedTemporaryFile() as tmp:
-        tmp.file.write(b'1 + 1')
+        tmp.file.write(b"1 + 1")
         tmp.file.flush()
         yield tmp
+
 
 @pytest.fixture(scope="function")
 def state():
     return State(
-        student_code = "",
-        solution_code = "",
-        reporter = Reporter(),
+        student_code="",
+        solution_code="",
+        reporter=Reporter(),
         # args below should be ignored
-        pre_exercise_code = "NA",
-        student_result = "", solution_result = "",
-        student_conn = None, solution_conn = None,
-        ast_dispatcher = Dispatcher(ast.AST, DUMMY_NODES, ParseHey())
-        )
+        pre_exercise_code="NA",
+        student_result="",
+        solution_result="",
+        student_conn=None,
+        solution_conn=None,
+        ast_dispatcher=Dispatcher(ast.AST, DUMMY_NODES, ParseHey()),
+    )
+
 
 def test_initial_state():
-    State(student_code = {'script.py': '1'}, solution_code = {'script.py': '1'},
-          reporter = Reporter(), pre_exercise_code = "",
-          student_result = "", solution_result = "",
-          student_conn = None, solution_conn = None,
-          ast_dispatcher = Dispatcher(ast.AST, DUMMY_NODES, ParseHey()))
+    State(
+        student_code={"script.py": "1"},
+        solution_code={"script.py": "1"},
+        reporter=Reporter(),
+        pre_exercise_code="",
+        student_result="",
+        solution_result="",
+        student_conn=None,
+        solution_conn=None,
+        ast_dispatcher=Dispatcher(ast.AST, DUMMY_NODES, ParseHey()),
+    )
+
 
 def test_check_file_use_fs(state, tf):
-    state.solution_code = { tf.name: '3 + 3' }
-    child = cf.check_file(state, tf.name, use_solution = True)
-    assert child.student_code == '1 + 1'
+    state.solution_code = {tf.name: "3 + 3"}
+    child = cf.check_file(state, tf.name, use_solution=True)
+    assert child.student_code == "1 + 1"
     assert_equal_ast(child.student_ast, ast.parse(child.student_code))
-    assert child.solution_code == '3 + 3'
+    assert child.solution_code == "3 + 3"
     assert_equal_ast(child.solution_ast, ast.parse(child.solution_code))
-    assert check_node(child, 'Expr', 0)
+    assert check_node(child, "Expr", 0)
+
 
 def test_check_file_use_fs_no_parse(state, tf):
-    state.solution_code = { tf.name: '3 + 3' }
-    child = cf.check_file(state, tf.name, parse = False)
-    assert child.student_code == '1 + 1'
+    state.solution_code = {tf.name: "3 + 3"}
+    child = cf.check_file(state, tf.name, parse=False)
+    assert child.student_code == "1 + 1"
     assert child.student_ast is None
     assert child.solution_ast is None
     with pytest.raises(TypeError):
-        assert check_node(child, 'Expr', 0)
+        assert check_node(child, "Expr", 0)
+
 
 def test_check_no_sol(state, tf):
-    child = cf.check_file(state, tf.name, use_fs = True)
+    child = cf.check_file(state, tf.name, use_fs=True)
     assert child.solution_code is None
+
 
 def test_check_dir(state):
     with TemporaryDirectory() as td:
         cf.has_dir(state, td)
 
+
 @pytest.fixture(scope="function")
 def code_state():
     return State(
-        student_code = {'script1.py': '1 + 1', 'script2.py': '2 + 2'},
-        solution_code = {'script1.py': '3 + 3', 'script2.py': '4 + 4'},
-        reporter = Reporter(),
+        student_code={"script1.py": "1 + 1", "script2.py": "2 + 2"},
+        solution_code={"script1.py": "3 + 3", "script2.py": "4 + 4"},
+        reporter=Reporter(),
         # args below should be ignored
-        pre_exercise_code = "NA",
-        student_result = "", solution_result = "",
-        student_conn = None, solution_conn = None,
-        ast_dispatcher = Dispatcher(ast.AST, DUMMY_NODES, ParseHey())
-        )
+        pre_exercise_code="NA",
+        student_result="",
+        solution_result="",
+        student_conn=None,
+        solution_conn=None,
+        ast_dispatcher=Dispatcher(ast.AST, DUMMY_NODES, ParseHey()),
+    )
+
 
 def test_check_file(code_state):
-    child = cf.check_file(code_state, 'script1.py', use_fs=False, use_solution=True)
+    child = cf.check_file(code_state, "script1.py", use_fs=False, use_solution=True)
     assert child.student_code == "1 + 1"
     assert_equal_ast(child.student_ast, ast.parse(child.student_code))
     assert_equal_ast(child.solution_ast, ast.parse(child.solution_code))
 
+
 def test_check_file_no_parse(code_state):
-    child = cf.check_file(code_state, 'script1.py', use_fs=False, parse = False, use_solution=True)
+    child = cf.check_file(
+        code_state, "script1.py", use_fs=False, parse=False, use_solution=True
+    )
     assert child.student_code == "1 + 1"
     assert child.student_ast is None
     assert child.solution_ast is None
-

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -68,7 +68,7 @@ def test_check_file_use_fs_no_parse(state, tf):
 
 def test_check_no_sol(state, tf):
     child = cf.check_file(state, tf.name, use_fs = True)
-    assert child.solution_code == None
+    assert child.solution_code is None
 
 def test_check_dir(state):
     with TemporaryDirectory() as td:

--- a/tests/test_check_logic.py
+++ b/tests/test_check_logic.py
@@ -5,75 +5,87 @@ from protowhat.Reporter import Reporter
 from protowhat.Test import TestFail as TF
 from functools import partial
 
+
 @pytest.fixture(scope="function")
 def state():
     return State(
-        student_code = "",
-        solution_code = "",
-        reporter = Reporter(),
+        student_code="",
+        solution_code="",
+        reporter=Reporter(),
         # args below should be ignored
-        pre_exercise_code = "NA", 
-        student_result = {'a': [1]}, solution_result = {'b': [2]},
-        student_conn = None, solution_conn = None)
+        pre_exercise_code="NA",
+        student_result={"a": [1]},
+        solution_result={"b": [2]},
+        student_conn=None,
+        solution_conn=None,
+    )
 
-def fails(state, msg=""): 
+
+def fails(state, msg=""):
     cl.fail(state, msg)
+
 
 def passes(state):
     return state
 
-@pytest.mark.parametrize('arg1', ( passes, [passes, passes] ))
-@pytest.mark.parametrize('arg2', ( passes, [passes, passes] ))
+
+@pytest.mark.parametrize("arg1", (passes, [passes, passes]))
+@pytest.mark.parametrize("arg2", (passes, [passes, passes]))
 def test_test_multi_pass_one(state, arg1, arg2):
     cl.multi(state, arg1, arg2)
 
-@pytest.mark.parametrize('arg1', ( fails, [passes, fails] ))
-def test_test_multi_fail_arg1(state, arg1):
-    with pytest.raises(TF): cl.multi(state, arg1)
 
-@pytest.mark.parametrize('arg2', ( fails, [passes, fails] ))
+@pytest.mark.parametrize("arg1", (fails, [passes, fails]))
+def test_test_multi_fail_arg1(state, arg1):
+    with pytest.raises(TF):
+        cl.multi(state, arg1)
+
+
+@pytest.mark.parametrize("arg2", (fails, [passes, fails]))
 def test_test_multi_fail_arg2(state, arg2):
-    with pytest.raises(TF): cl.multi(state, passes, arg2)
+    with pytest.raises(TF):
+        cl.multi(state, passes, arg2)
+
 
 def test_check_or_pass(state):
     cl.check_or(state, passes, fails)
 
+
 def test_check_or_fail(state):
     f1, f2 = partial(fails, msg="f1"), partial(fails, msg="f2")
-    with pytest.raises(TF, match='f1'):
+    with pytest.raises(TF, match="f1"):
         cl.check_or(state, f1, f2)
 
-@pytest.mark.parametrize('arg1', [
-    fails,
-    [fails, fails]
-])
-def test_check_not_pass(state, arg1):
-    cl.check_not(state, arg1, msg='fail')
 
-@pytest.mark.parametrize('arg1', [
-    passes,
-    [passes, fails],
-    [fails, passes]
-])
+@pytest.mark.parametrize("arg1", [fails, [fails, fails]])
+def test_check_not_pass(state, arg1):
+    cl.check_not(state, arg1, msg="fail")
+
+
+@pytest.mark.parametrize("arg1", [passes, [passes, fails], [fails, passes]])
 def test_check_not_fail(state, arg1):
-    with pytest.raises(TF, match='boom'):
-        cl.check_not(state, arg1, msg='boom')
+    with pytest.raises(TF, match="boom"):
+        cl.check_not(state, arg1, msg="boom")
+
 
 def test_check_correct_pass(state):
     cl.check_correct(state, passes, fails)
 
+
 def test_check_correct_fail_force_diagnose(state):
     state.force_diagnose = True
-    with pytest.raises(TF, match='f2'):
+    with pytest.raises(TF, match="f2"):
         cl.check_correct(state, passes, partial(fails, msg="f2"))
+
 
 def test_check_correct_fail_msg(state):
     f1, f2 = partial(fails, msg="f1"), partial(fails, msg="f2")
-    with pytest.raises(TF, match='f2'):
+    with pytest.raises(TF, match="f2"):
         cl.check_correct(state, f1, f2)
+
 
 @pytest.mark.debug
 def test_check_correct_fail_multi_msg(state):
-    f1, f2, f3 = [partial(fails, msg="f%s"%ii) for ii in range(1, 4)]
-    with pytest.raises(TF, match='f2'):
+    f1, f2, f3 = [partial(fails, msg="f%s" % ii) for ii in range(1, 4)]
+    with pytest.raises(TF, match="f2"):
         cl.check_correct(state, [f1, f3], [f2, f3])

--- a/tests/test_check_logic.py
+++ b/tests/test_check_logic.py
@@ -48,7 +48,7 @@ def test_check_or_fail(state):
     [fails, fails]
 ])
 def test_check_not_pass(state, arg1):
-    cl.check_not(state, arg1, incorrect_msg='fail')
+    cl.check_not(state, arg1, msg='fail')
 
 @pytest.mark.parametrize('arg1', [
     passes,
@@ -57,7 +57,7 @@ def test_check_not_pass(state, arg1):
 ])
 def test_check_not_fail(state, arg1):
     with pytest.raises(TF, match='boom'):
-        cl.check_not(state, arg1, incorrect_msg='boom')
+        cl.check_not(state, arg1, msg='boom')
 
 def test_check_correct_pass(state):
     cl.check_correct(state, passes, fails)

--- a/tests/test_check_simple.py
+++ b/tests/test_check_simple.py
@@ -6,50 +6,61 @@ from protowhat.Reporter import Reporter
 from protowhat.Test import TestFail as TF
 import pytest
 
-sct_ctx = {'has_chosen': has_chosen, 'success_msg': success_msg}
+sct_ctx = {"has_chosen": has_chosen, "success_msg": success_msg}
+
 
 def prepare_state(student_code):
     return State(
-        student_code = student_code,
-        reporter = Reporter(),
+        student_code=student_code,
+        reporter=Reporter(),
         # args below should be ignored
-        solution_code = "NA", pre_exercise_code = "NA", 
-        solution_ast = "NA", student_ast = "NA",
-        student_result = [], solution_result = [],
-        student_conn = None, solution_conn = None
+        solution_code="NA",
+        pre_exercise_code="NA",
+        solution_ast="NA",
+        student_ast="NA",
+        student_result=[],
+        solution_result=[],
+        student_conn=None,
+        solution_conn=None,
     )
+
 
 def test_has_chosen_alone_pass():
     state = prepare_state("selected_option = 1")
-    has_chosen(state, 1, ['good', 'bad'])
+    has_chosen(state, 1, ["good", "bad"])
+
 
 def test_has_chosen_alone_fail():
     state = prepare_state("selected_option = 2")
     with pytest.raises(TF):
-        has_chosen(state, 1, ['good', 'bad'])
+        has_chosen(state, 1, ["good", "bad"])
+
 
 def test_has_chosen_chain_pass():
     state = prepare_state("selected_option = 1")
-    Chain(state, sct_ctx).has_chosen(1, ['good', 'bad'])
-    assert state.reporter.build_final_payload()['message'] == 'good'
+    Chain(state, sct_ctx).has_chosen(1, ["good", "bad"])
+    assert state.reporter.build_final_payload()["message"] == "good"
+
 
 def test_has_chosen_chain_fail():
     state = prepare_state("selected_option = 2")
-    with pytest.raises(TF, match = 'bad'):
-        Chain(state, sct_ctx).has_chosen(1, ['good', 'bad'])
+    with pytest.raises(TF, match="bad"):
+        Chain(state, sct_ctx).has_chosen(1, ["good", "bad"])
+
 
 def test_success_msg_pass():
     state = prepare_state("")
     success_msg(state, "NEW SUCCESS MSG")
 
     sct_payload = state.reporter.build_final_payload()
-    assert sct_payload['correct'] == True
-    assert sct_payload['message'] == "NEW SUCCESS MSG"
+    assert sct_payload["correct"] == True
+    assert sct_payload["message"] == "NEW SUCCESS MSG"
+
 
 def test_success_msg_pass_ex():
     state = prepare_state("")
     Chain(state, sct_ctx).success_msg("NEW SUCCESS MSG")
 
     sct_payload = state.reporter.build_final_payload()
-    assert sct_payload['correct'] == True
-    assert sct_payload['message'] == "NEW SUCCESS MSG"
+    assert sct_payload["correct"] == True
+    assert sct_payload["message"] == "NEW SUCCESS MSG"

--- a/tests/test_sct_syntax.py
+++ b/tests/test_sct_syntax.py
@@ -5,76 +5,96 @@ import pytest
 state_dec = state_dec_gen(State, {})
 Ex = ExGen(State, {})
 
+
 @pytest.fixture
 def addx():
     return lambda state, x: state + x
 
+
 @pytest.fixture
 def f():
-    return F._from_func(lambda state, b: state + b, b = 'b')
+    return F._from_func(lambda state, b: state + b, b="b")
+
 
 @pytest.fixture
 def f2():
-    return F._from_func(lambda state, c: state + c, c = 'c')
+    return F._from_func(lambda state, c: state + c, c="c")
+
 
 def test_f_from_func(f):
-    assert f('a') == 'ab'
+    assert f("a") == "ab"
+
 
 def test_f_sct_copy_kw(addx):
-    assert F()._sct_copy(addx)(x = 'x')('state') == 'statex'
+    assert F()._sct_copy(addx)(x="x")("state") == "statex"
+
 
 def test_f_sct_copy_pos(addx):
-    assert F()._sct_copy(addx)('x')('state') == 'statex'
+    assert F()._sct_copy(addx)("x")("state") == "statex"
+
 
 def test_ex_sct_copy_kw(addx):
-    assert Ex('state')._sct_copy(addx)(x = 'x')._state == 'statex'
+    assert Ex("state")._sct_copy(addx)(x="x")._state == "statex"
+
 
 def test_ex_sct_copy_pos(addx):
-    assert Ex('state')._sct_copy(addx)('x')._state == 'statex'
+    assert Ex("state")._sct_copy(addx)("x")._state == "statex"
+
 
 def test_f_2_funcs(f, addx):
     g = f._sct_copy(addx)
-    
-    assert g(x = 'x')('a') == 'abx'
+
+    assert g(x="x")("a") == "abx"
+
 
 def test_f_add_unary_func(f):
-    g = f >> (lambda state: state + 'c')
-    assert g('a') == 'abc'
+    g = f >> (lambda state: state + "c")
+    assert g("a") == "abc"
+
 
 def test_f_add_f(f, f2):
     g = f >> f2
-    assert g('a') == 'abc'
+    assert g("a") == "abc"
+
 
 def test_f_from_state_dec(addx):
     dec_addx = state_dec(addx)
-    f = dec_addx(x = 'x')
+    f = dec_addx(x="x")
     isinstance(f, F)
-    assert f('state') == 'statex'
+    assert f("state") == "statex"
+
 
 @pytest.fixture
 def ex():
-    return Ex('state')._sct_copy(lambda state, x: state + x)('x')
+    return Ex("state")._sct_copy(lambda state, x: state + x)("x")
+
 
 def test_ex_add_f(ex, f):
-    (ex >> f)._state = 'statexb'
+    (ex >> f)._state = "statexb"
+
 
 def test_ex_add_unary(ex):
-    (ex >> (lambda state: state + 'b'))._state == 'statexb'
+    (ex >> (lambda state: state + "b"))._state == "statexb"
+
 
 def test_ex_add_ex_err(ex):
-    with pytest.raises(BaseException): ex >> ex
+    with pytest.raises(BaseException):
+        ex >> ex
+
 
 def test_f_add_ex_err(f, ex):
-    with pytest.raises(BaseException): f >> ex
+    with pytest.raises(BaseException):
+        f >> ex
 
 
 from protowhat.Reporter import Reporter
+
+
 def test_state_dec_instant_eval():
     state = State("student_code", "", "", None, None, {}, {}, Reporter())
 
     @state_dec
-    def stu_code(state, x = 'x'):
+    def stu_code(state, x="x"):
         return state.student_code + x
 
     assert stu_code(state) == "student_codex"
-

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -4,8 +4,10 @@ from protowhat.selectors import Selector
 def test_selector_standalone():
     # use python's builtin ast library
     from ast import Expr, Num
-    Expr._priority = 0; Num._priority = 1
-    node = Expr(value = Num(n = 1))
+
+    Expr._priority = 0
+    Num._priority = 1
+    node = Expr(value=Num(n=1))
 
     sel = Selector(Num)
     sel.visit(node)

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,7 +1,5 @@
 from protowhat.selectors import Selector
 
-import pytest
-
 
 def test_selector_standalone():
     # use python's builtin ast library

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from protowhat.utils import legacy_signature
+
+
+def test_legacy_signature():
+    @legacy_signature(old_arg1="arg1", old_arg2="arg2")
+    def func(arg1, arg2=1):
+        return arg1 + arg2
+
+    assert func(1) == 2
+    assert func(arg1=1) == 2
+    assert func(old_arg1=1) == 2
+    assert func(1, arg2=2) == 3
+    assert func(1, old_arg2=2) == 3
+    assert func(arg1=1, old_arg2=2) == 3
+    assert func(old_arg1=1, arg2=2) == 3
+    assert func(old_arg1=1, old_arg2=2) == 3

--- a/tests/test_utils_ast.py
+++ b/tests/test_utils_ast.py
@@ -3,7 +3,8 @@ import bashlex.errors
 from protowhat import utils_ast
 from collections import OrderedDict
 
-def dump_bash(obj, parent_cls = bashlex.ast.node, v = False):
+
+def dump_bash(obj, parent_cls=bashlex.ast.node, v=False):
     """Takes a bashlex AST and returns it structured as a dictionary.
 
     Each dictionary entry has two fields:
@@ -12,22 +13,28 @@ def dump_bash(obj, parent_cls = bashlex.ast.node, v = False):
     
     """
     # pull element out of single entry lists
-    if isinstance(obj, (list, tuple)) and len(obj) == 1: obj = obj[0]
+    if isinstance(obj, (list, tuple)) and len(obj) == 1:
+        obj = obj[0]
     # dump to dict
     if isinstance(obj, parent_cls):
-        if obj.kind in ['word', 'reservedword'] and not v:
+        if obj.kind in ["word", "reservedword"] and not v:
             return obj.word
         fields = OrderedDict()
-        for name in [el for el in obj.__dict__.keys() if el not in ('kind', 'pos')]:
+        for name in [el for el in obj.__dict__.keys() if el not in ("kind", "pos")]:
             attr = getattr(obj, name)
-            if   isinstance(attr, parent_cls): fields[name] = dump_bash(attr, parent_cls, v)
-            elif isinstance(attr, list) and len(attr) == 0: continue
-            elif isinstance(attr, list): fields[name] = [dump_bash(x, parent_cls, v) for x in attr]
-            else: fields[name] = attr
-        return {'type': obj.kind, 'data': fields}
+            if isinstance(attr, parent_cls):
+                fields[name] = dump_bash(attr, parent_cls, v)
+            elif isinstance(attr, list) and len(attr) == 0:
+                continue
+            elif isinstance(attr, list):
+                fields[name] = [dump_bash(x, parent_cls, v) for x in attr]
+            else:
+                fields[name] = attr
+        return {"type": obj.kind, "data": fields}
     elif isinstance(obj, list):
         return [dump_bash(x, parent_cls, v) for x in obj]
-    else: raise Exception("received non-node object?") 
+    else:
+        raise Exception("received non-node object?")
 
 
 def test_AstModule_load():

--- a/tests/test_utils_ast.py
+++ b/tests/test_utils_ast.py
@@ -32,8 +32,16 @@ def dump_bash(obj, parent_cls = bashlex.ast.node, v = False):
 
 def test_AstModule_load():
     cmd = """for ii in {1..10}; do echo $ii; done"""
-    ast_mod = utils_ast.AstModule(bashlex.parse, bashlex.errors.ParsingError)
-    data_dict = dump_bash(ast_mod.parse(cmd))
-    tree = ast_mod.load(data_dict)
 
-    assert type(tree.list[0]) == ast_mod.classes['for']
+    class Bashlex(utils_ast.AstModule):
+        ParseError = bashlex.errors.ParsingError
+
+        def parse(self, code, **kwargs):
+            # dump parse tree and
+            # use it to dynamically update this AstModule
+            return self.load(dump_bash(bashlex.parse(code)))
+
+    parser = Bashlex()
+    tree = parser.parse(cmd)
+
+    assert type(tree.list[0]) == parser.nodes["for"]


### PR DESCRIPTION
Sharing more functionality means less duplicated effort and it improves the consistency of architectural concepts across all xwhat libraries in Python.

The most important change is that `do_test` now runs a test as in pythonwhat, instead of accepting a feedback string.
While the default implementation of `Test` is to fail, the explicit `Fail` subclass can now be used if that is the intention.
The `report(feedback: Feedback)` method on the State class reintroduces a short way to gather exercise feedback, equivalent to `do_test(Fail(Feedback(msg)))`, while also setting highlight info.