### PR TITLE
Refactor for xwhat consistency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 import protowhat
 
@@ -32,21 +32,21 @@ import protowhat
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'protowhat'
-copyright = '2018, DataCamp'
-author = 'DataCamp'
+project = "protowhat"
+copyright = "2018, DataCamp"
+author = "DataCamp"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -67,14 +67,14 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
 add_module_names = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -84,7 +84,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -100,19 +100,18 @@ html_theme = 'sphinx_rtd_theme'
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'protowhatdoc'
+htmlhelp_basename = "protowhatdoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = { }
+latex_elements = {}
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'protowhat.tex', 'protowhat Documentation',
-     'DataCamp', 'manual'),
+    (master_doc, "protowhat.tex", "protowhat Documentation", "DataCamp", "manual")
 ]
 
 
@@ -120,10 +119,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'protowhat', 'protowhat Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "protowhat", "protowhat Documentation", [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -131,7 +127,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'protowhat', 'protowhat Documentation',
-     author, 'protowhat', 'Prototype library for python-based whats on DataCamp',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "protowhat",
+        "protowhat Documentation",
+        author,
+        "protowhat",
+        "Prototype library for python-based whats on DataCamp",
+        "Miscellaneous",
+    )
 ]

--- a/example/example_helper.py
+++ b/example/example_helper.py
@@ -2,18 +2,21 @@ import ast
 import inspect
 import asttokens
 
+
 class PythonAst:
     def get_text(self, full_text=None):
-        atok = asttokens.ASTTokens(code, tree = self)
+        atok = asttokens.ASTTokens(code, tree=self)
         return atok.get_text(self)
+
 
 def patch_ast():
     # forces class to use PythonAst as a mixin
     # allows them to use get_text method
     for obj in ast.__dict__.values():
         if inspect.isclass(obj) and issubclass(obj, ast.AST):
-            if obj == ast.AST or PythonAst in obj.__bases__: continue
-            obj.__bases__ = obj.__bases__ + (PythonAst, )
+            if obj == ast.AST or PythonAst in obj.__bases__:
+                continue
+            obj.__bases__ = obj.__bases__ + (PythonAst,)
             obj._priority = 0
 
     # add AstNode, and ParseError classes for Dispatcher

--- a/example/example_helper.py
+++ b/example/example_helper.py
@@ -5,7 +5,7 @@ import asttokens
 
 class PythonAst:
     def get_text(self, full_text=None):
-        atok = asttokens.ASTTokens(code, tree=self)
+        atok = asttokens.ASTTokens(full_text, tree=self)
         return atok.get_text(self)
 
 

--- a/example/example_helper.py
+++ b/example/example_helper.py
@@ -3,7 +3,7 @@ import inspect
 import asttokens
 
 class PythonAst:
-    def get_text(self, code):
+    def get_text(self, full_text=None):
         atok = asttokens.ASTTokens(code, tree = self)
         return atok.get_text(self)
 

--- a/example/example_python.ipynb
+++ b/example/example_python.ipynb
@@ -84,16 +84,16 @@
     "For the sake of demonstration, this makes it so nodes in the builtin \n",
     "ast module have the following methods:\n",
     "\n",
-    "    * _get_text(code): returns the code corresponding to that node.\n",
-    "    * _get_field_names: returns nodes field names (e.g. module has a body field)\n",
+    "    * get_text(code): returns the code corresponding to that node.\n",
+    "    * _fields: returns nodes field names (e.g. module has a body field)\n",
     "    * _priority: can ignore for now\n",
     "\n",
     "See protowhat.utils_ast.AstNode for the required methods an AST class needs\n",
     "\"\"\"\n",
     "patch_ast()\n",
     "\n",
-    "print(tree._get_text(code))\n",
-    "print(tree.body[0].value.func._get_text(code))"
+    "print(tree.get_text(code))\n",
+    "print(tree.body[0].value.func.get_text(code))"
    ]
   },
   {
@@ -150,8 +150,8 @@
     "expr is tree.body[0]\n",
     "\n",
     "names = d('Name', slice(None), tree, priority = 99)\n",
-    "names[0]._get_text(code)    # x\n",
-    "names[1]._get_text(code)    # n"
+    "names[0].get_text(code)    # x\n",
+    "names[1].get_text(code)    # n"
    ]
   },
   {
@@ -210,7 +210,7 @@
     "s_call = check_node(s_expr, 'Call', 0)\n",
     "\n",
     "s_call.student_ast    # call node\n",
-    "s_call.student_ast._get_text(s.student_code)\n",
+    "s_call.student_ast.get_text(s.student_code)\n",
     "\n",
     "#check_node(s, 'Expr', 1)     # raises TestFail with feedback"
    ]

--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -20,13 +20,6 @@ class Feedback:
 
         return result or {}
 
-    def get_highlight_info(self):
-        formatted_info = self.get_highlight_data()
-        for k in ["column_start", "column_end"]:
-            if k in formatted_info:
-                formatted_info[k] += 1
-        return formatted_info
-
 
 class InstructorError(Exception):
     pass

--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -7,21 +7,21 @@ class Feedback:
             self.highlight = getattr(state, "highlight", None)
             self.highlighting_disabled = state.highlighting_disabled
 
-    def _line_info(self):
+    def _highlight_data(self):
         return self.highlight.get_position()
 
-    def get_line_info(self):
+    def get_highlight_data(self):
         result = None
         try:
             if self.highlight is not None and not self.highlighting_disabled:
-                result = self._line_info()
+                result = self._highlight_data()
         except:
             pass
 
         return result or {}
 
-    def get_formatted_line_info(self):
-        formatted_info = self.get_line_info()
+    def get_highlight_info(self):
+        formatted_info = self.get_highlight_data()
         for k in ["column_start", "column_end"]:
             if k in formatted_info:
                 formatted_info[k] += 1

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -45,7 +45,7 @@ class Reporter:
         return {
             "correct": False,
             "message": Reporter.to_html(feedback.message),
-            **feedback.get_formatted_line_info(),
+            **feedback.get_highlight_info(),
         }
 
     def build_final_payload(self):

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -32,12 +32,12 @@ class TestRunner:
         return [self.do_test(test, **kwargs) for test in tests]
 
     @property
-    def failure_feedback(self):
-        return list(filter(lambda test: test.result is False, self.tests))
+    def failures(self):
+        return list(filter(lambda test: test.result == False, self.tests))
 
     @property
     def has_failed(self):
-        return len(self.failure_feedback) > 0
+        return len(self.failures) > 0
 
 
 class Reporter(TestRunner):

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -13,6 +13,7 @@ class Reporter:
     This class holds the feedback- or success message and tracks whether there are failed tests
     or not. All tests are executed trough do_test() in the Reporter.
     """
+
     def __init__(self, errors=None):
         self.errors = errors
         self.errors_allowed = False
@@ -24,23 +25,21 @@ class Reporter:
     def allow_errors(self):
         self.errors_allowed = True
 
-    def do_test(self, test):
+    def do_test(self, test, fail_hard=True):
         """Raise failing test.
 
         Raise a ``TestFail`` object, containing the feedback message and highlight information.
         """
+        result = None
+        feedback = None
+        test()
         if isinstance(test, Test):
-            test.test()
             result = test.result
-            if not result:
+            if not result and fail_hard:
                 feedback = test.get_feedback()
                 raise TestFail(feedback, self.build_failed_payload(feedback))
 
-        else:
-            result = None
-            test()  # run function for side effects
-
-        return result
+        return result, feedback
 
     def build_failed_payload(self, feedback):
         return {

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -1,6 +1,6 @@
 import re
 import markdown2
-from protowhat.Test import TestFail, Test
+from protowhat.Test import Test
 
 """
 This file holds the reporter class.
@@ -11,7 +11,7 @@ class TestRunner:
     def __init__(self):
         self.tests = []
 
-    def do_test(self, test, fail_hard=True):
+    def do_test(self, test):
         """Raise failing test.
 
         Raise a ``TestFail`` object, containing the feedback message and highlight information.
@@ -22,18 +22,17 @@ class TestRunner:
         if isinstance(test, Test):
             self.tests.append(test)
             result = test.result
-            if not result and fail_hard:
+            if not result:
                 feedback = test.get_feedback()
-                raise TestFail(feedback, self.build_failed_payload(feedback))
 
         return result, feedback
 
-    def do_tests(self, tests, **kwargs):
-        return [self.do_test(test, **kwargs) for test in tests]
+    def do_tests(self, tests):
+        return [self.do_test(test) for test in tests]
 
     @property
     def failures(self):
-        return list(filter(lambda test: test.result == False, self.tests))
+        return list(filter(lambda test: test.result is False, self.tests))
 
     @property
     def has_failed(self):
@@ -84,6 +83,6 @@ class TestRunnerProxy(TestRunner):
         super().__init__()
         self.runner = runner
 
-    def do_test(self, test, fail_hard=False):
+    def do_test(self, test):
         self.tests.append(test)
-        return self.runner.do_test(test, fail_hard=fail_hard)
+        return self.runner.do_test(test)

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -46,10 +46,11 @@ class Reporter(TestRunner):
     or not. All tests are executed trough do_test() in the Reporter.
     """
 
-    def __init__(self, errors=None):
+    def __init__(self, errors=None, highlight_offset=None):
         super().__init__()
         self.errors = errors
         self.errors_allowed = False
+        self.highlight_offset = highlight_offset or {}
         self.success_msg = "Great work!"
 
     def get_errors(self):
@@ -59,10 +60,15 @@ class Reporter(TestRunner):
         self.errors_allowed = True
 
     def build_failed_payload(self, feedback):
+        highlight = feedback.get_highlight_info()
+        for k in self.highlight_offset:
+            if k in highlight:
+                highlight[k] = highlight[k] + self.highlight_offset[k]
+
         return {
             "correct": False,
             "message": Reporter.to_html(feedback.message),
-            **feedback.get_highlight_info(),
+            **highlight,
         }
 
     def build_final_payload(self):

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -87,5 +87,3 @@ class TestRunnerProxy(TestRunner):
     def do_test(self, test, fail_hard=False):
         self.tests.append(test)
         return self.runner.do_test(test, fail_hard=fail_hard)
-
-

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -48,7 +48,8 @@ class TestRunnerProxy(TestRunner):
         self.runner = runner
 
     def do_test(self, test):
-        self.tests.append(test)
+        if isinstance(test, Test):
+            self.tests.append(test)
         return self.runner.do_test(test)
 
 

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -1,4 +1,6 @@
 import re
+from copy import copy
+
 import markdown2
 from protowhat.Test import Test
 
@@ -39,15 +41,26 @@ class TestRunner:
         return len(self.failures) > 0
 
 
-class Reporter(TestRunner):
+class TestRunnerProxy(TestRunner):
+    # Checks using this might be split into more atomic checks
+    def __init__(self, runner: TestRunner):
+        super().__init__()
+        self.runner = runner
+
+    def do_test(self, test):
+        self.tests.append(test)
+        return self.runner.do_test(test)
+
+
+class Reporter(TestRunnerProxy):
     """Do reporting.
 
     This class holds the feedback- or success message and tracks whether there are failed tests
     or not. All tests are executed trough do_test() in the Reporter.
     """
 
-    def __init__(self, errors=None, highlight_offset=None):
-        super().__init__()
+    def __init__(self, runner=None, errors=None, highlight_offset=None):
+        super().__init__(runner or TestRunner())
         self.errors = errors
         self.errors_allowed = False
         self.highlight_offset = highlight_offset or {}
@@ -60,10 +73,17 @@ class Reporter(TestRunner):
         self.errors_allowed = True
 
     def build_failed_payload(self, feedback):
-        highlight = feedback.get_highlight_info()
-        for k in self.highlight_offset:
+        highlight_offset = copy(self.highlight_offset)
+        if (
+            "line_start" in highlight_offset
+            and "line_end" not in highlight_offset
+        ):
+            highlight_offset["line_end"] = highlight_offset["line_start"]
+
+        highlight = copy(feedback.get_highlight_info())
+        for k in highlight_offset:
             if k in highlight:
-                highlight[k] = highlight[k] + self.highlight_offset[k]
+                highlight[k] = highlight[k] + highlight_offset[k]
 
         return {
             "correct": False,
@@ -81,14 +101,3 @@ class Reporter(TestRunner):
     @staticmethod
     def to_html(msg):
         return re.sub("<p>(.*)</p>", "\\1", markdown2.markdown(msg)).strip()
-
-
-class TestRunnerProxy(TestRunner):
-    # Checks using this might be split into more atomic checks
-    def __init__(self, runner: TestRunner):
-        super().__init__()
-        self.runner = runner
-
-    def do_test(self, test):
-        self.tests.append(test)
-        return self.runner.do_test(test)

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -88,7 +88,8 @@ class State:
         if self.creator is not None:
             return self.creator["args"]["state"]
 
-    def get_state_history(self):
+    @property
+    def state_history(self):
         history = [self]
         while history[-1].parent_state is not None:
             history.append(history[-1].parent_state)
@@ -99,7 +100,7 @@ class State:
         rev_checks = filter(
             lambda x: x.creator is not None
             and x.creator["type"] in ["check_edge", "check_node"],
-            reversed(self.get_state_history()),
+            reversed(self.state_history),
         )
         try:
             last = next(rev_checks)

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -4,7 +4,7 @@ from jinja2 import Template
 
 from protowhat.selectors import DispatcherInterface
 from protowhat.Feedback import Feedback, InstructorError
-from protowhat.Test import Fail, Test
+from protowhat.Test import Fail, Test, TestFail
 
 
 class DummyDispatcher(DispatcherInterface):
@@ -131,11 +131,14 @@ class State:
 
         return self.do_test(test)
 
-    def do_test(self, test: Test, **kwargs):
-        return self.reporter.do_test(test, **kwargs)
+    def do_test(self, test: Test):
+        result, feedback = self.reporter.do_test(test)
+        if result is False:
+            raise TestFail(feedback, self.reporter.build_failed_payload(feedback))
+        return result, feedback
 
-    def do_tests(self, tests, **kwargs):
-        return [self.do_test(test, **kwargs) for test in tests]
+    def do_tests(self, tests):
+        return [self.do_test(test) for test in tests]
 
     def to_child(self, append_message="", **kwargs):
         """Basic implementation of returning a child state"""

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -17,6 +17,9 @@ class DummyDispatcher(DispatcherInterface):
     def find(self, name, node, *args, **kwargs):
         return []
 
+    def select(self, path: str, node):
+        return None
+
     def parse(self, code):
         return self.ParseError()
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -40,7 +40,6 @@ class State:
         creator=None,
         solution_ast=None,
         student_ast=None,
-        fname=None,
         ast_dispatcher=None,
     ):
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -131,8 +131,11 @@ class State:
 
         return self.do_test(test)
 
-    def do_test(self, test: Test):
-        return self.reporter.do_test(test)
+    def do_test(self, test: Test, **kwargs):
+        return self.reporter.do_test(test, **kwargs)
+
+    def do_tests(self, tests, **kwargs):
+        return [self.do_test(test, **kwargs) for test in tests]
 
     def to_child(self, append_message="", **kwargs):
         """Basic implementation of returning a child state"""

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -1,5 +1,4 @@
 from copy import copy
-import inspect
 from jinja2 import Template
 
 from protowhat.selectors import DispatcherInterface
@@ -46,9 +45,11 @@ class State:
         student_ast=None,
         ast_dispatcher=None,
     ):
-
-        for k, v in locals().items():
+        args = locals().copy()
+        self.params = list()
+        for k, v in args.items():
             if k != "self":
+                self.params.append(k)
                 setattr(self, k, v)
 
         self.messages = messages if messages else []
@@ -61,8 +62,6 @@ class State:
             self.solution_ast = self.parse(self.solution_code, test=False)
         if isinstance(self.student_code, str) and self.student_ast is None:
             self.student_ast = self.parse(self.student_code)
-
-        self._child_params = inspect.signature(State.__init__).parameters
 
     def parse(self, text, test=True):
         result = None
@@ -144,7 +143,7 @@ class State:
     def to_child(self, append_message="", **kwargs):
         """Basic implementation of returning a child state"""
 
-        bad_pars = set(kwargs) - set(self._child_params)
+        bad_pars = set(kwargs) - set(self.params)
         if bad_pars:
             raise KeyError("Invalid init params for State: %s" % ", ".join(bad_pars))
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -14,7 +14,7 @@ class DummyDispatcher(DispatcherInterface):
 
         self.ParseError = ParseError
 
-    def __call__(self, name, node, *args, **kwargs):
+    def find(self, name, node, *args, **kwargs):
         return []
 
     def parse(self, code):

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -37,6 +37,7 @@ class State:
         reporter,
         force_diagnose=False,
         highlighting_disabled=False,
+        messages=None,
         creator=None,
         solution_ast=None,
         student_ast=None,
@@ -47,10 +48,10 @@ class State:
             if k != "self":
                 setattr(self, k, v)
 
+        self.messages = messages if messages else []
+
         if ast_dispatcher is None:
             self.ast_dispatcher = self.get_dispatcher()
-
-        self.messages = []
 
         # Parse solution and student code
         if isinstance(self.solution_code, str) and self.solution_ast is None:

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -40,20 +40,20 @@ class Test:
 
         self.result = None
 
-    def test(self):
+    def __call__(self):
         """
         Wrapper around specific tests. Tests only get one chance.
         """
         if self.result is None:
             try:
-                self.specific_test()
+                self.test()
                 self.result = np.array(self.result).all()
             except:
                 self.result = False
 
-    def specific_test(self):
+    def test(self):
         """
-        Perform the actual test. For the standard test, result will be set to False.
+        Perform the actual test.
         """
         raise NotImplementedError
 
@@ -62,5 +62,5 @@ class Test:
 
 
 class Fail(Test):
-    def specific_test(self):
+    def test(self):
         self.result = False

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -47,7 +47,7 @@ class Test:
         if self.result is None:
             try:
                 self.test()
-                self.result = np.array(self.result).all()
+                self.result = bool(np.array(self.result).all())
             except:
                 self.result = False
 

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -1,67 +1,55 @@
 from pathlib import Path
-from collections.abc import Mapping
 
 from protowhat.Feedback import Feedback
 
 
 def check_file(
     state,
-    fname,
-    missing_msg="Did you create a file named `{}`?",
-    is_dir_msg="Want to check a file named `{}`, but found a directory.",
+    path,
+    missing_msg="Did you create the file `{}`?",
+    is_dir_msg="Want to check the file `{}`, but found a directory.",
     parse=True,
-    use_fs=True,
-    use_solution=False,
+    solution_code=None,
 ):
     """Test whether file exists, and make its contents the student code.
 
     Note: this SCT fails if the file is a directory.
     """
 
-    if use_fs:
-        p = Path(fname)
-        if not p.exists():
-            state.report(Feedback(missing_msg.format(fname)))  # test file exists
-        if p.is_dir():
-            state.report(Feedback(is_dir_msg.format(fname)))  # test its not a dir
+    p = Path(path)
+    if not p.exists():
+        state.report(Feedback(missing_msg.format(path)))  # test file exists
+    if p.is_dir():
+        state.report(Feedback(is_dir_msg.format(path)))  # test its not a dir
 
-        code = p.read_text()
-    else:
-        code = _get_fname(state, "student_code", fname)
+    code = p.read_text()
 
-        if code is None:
-            state.report(Feedback(missing_msg.format(fname)))  # test file exists
-
-    sol_kwargs = {"solution_code": None, "solution_ast": None}
-    if use_solution:
-        sol_code = _get_fname(state, "solution_code", fname)
-        if sol_code is None:
-            raise Exception("Solution code does not have file named: %s" % fname)
-        sol_kwargs["solution_code"] = sol_code
+    sol_kwargs = {"solution_code": solution_code, "solution_ast": None}
+    if solution_code:
         sol_kwargs["solution_ast"] = (
-            state.parse(sol_code, test=False) if parse else None
+            state.parse(solution_code, test=False) if parse else None
         )
 
     return state.to_child(
+        append_message="We checked the file `{}`. ".format(path),
         student_code=code,
         student_ast=state.parse(code) if parse else None,
         **sol_kwargs
     )
 
 
-def _get_fname(state, attr, fname):
-    code_dict = getattr(state, attr)
-    if not isinstance(code_dict, Mapping):
-        raise TypeError(
-            "Can't get {} from state.{}, which must be a " "dictionary or Mapping."
-        )
-
-    return code_dict.get(fname)
-
-
-def has_dir(state, fname, incorrect_msg="Did you create a directory named `{}`?"):
+def has_dir(state, path, incorrect_msg="Did you create a directory `{}`?"):
     """Test whether a directory exists."""
-    if not Path(fname).is_dir():
-        state.report(Feedback(incorrect_msg.format(fname)))
+    if not Path(path).is_dir():
+        state.report(Feedback(incorrect_msg.format(path)))
 
     return state
+
+
+# helper functions
+def load_file(relative_path, prefix=""):
+    # the prefix can be partialed
+    # so it's not needed to copy the common part of paths
+    p = Path(prefix, relative_path)
+
+    return p.read_text()

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -45,7 +45,6 @@ def check_file(
     return state.to_child(
         student_code=code,
         student_ast=state.parse(code) if parse else None,
-        fname=fname,
         **sol_kwargs
     )
 

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -296,7 +296,8 @@ def has_equal_ast(
 
     sol_str = get_str(state.solution_ast, state.solution_code, sql)
     _msg = incorrect_msg.format(
-        ast_path=state.get_ast_path() or "highlighted code",
+        ast_path=state.get_ast_path()
+        or ("code" if state.highlighting_disabled else "highlighted code"),
         extra="The checker expected to find `{}` in there.".format(sol_str)
         if sol_str
         else "Something is missing.",

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -90,14 +90,8 @@ def check_node(
             _msg = MSG_CHECK_FALLBACK
         state.report(Feedback(_msg))
 
-    action = {
-        "type": "check_node",
-        "kwargs": {"name": name, "index": index},
-        "node": stu_stmt,
-    }
-
     return state.to_child(
-        student_ast=stu_stmt, solution_ast=sol_stmt, history=state.history + (action,)
+        student_ast=stu_stmt, solution_ast=sol_stmt
     )
 
 
@@ -159,10 +153,8 @@ def check_edge(
     if stu_attr is None and sol_attr is not None:
         state.report(Feedback(_msg))
 
-    action = {"type": "check_edge", "kwargs": {"name": name, "index": index}}
-
     return state.to_child(
-        student_ast=stu_attr, solution_ast=sol_attr, history=state.history + (action,)
+        student_ast=stu_attr, solution_ast=sol_attr
     )
 
 

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -1,3 +1,5 @@
+import re
+
 from functools import partial, wraps
 
 from protowhat.Feedback import Feedback
@@ -125,10 +127,14 @@ def check_edge(
             clause =  select.check_edge('from_clause', None)    # get from_clause (a list)
             clause2 = select.check_edge('from_clause', 0)       # get first entry in from_clause
     """
+    def select(node_name, node):
+        attr = state.ast_dispatcher.select(node_name, node)
+        if attr and isinstance(attr, list) and index is not None:
+            attr = attr[index]
+        return attr
+
     try:
-        sol_attr = getattr(state.solution_ast, name)
-        if sol_attr and isinstance(sol_attr, list) and index is not None:
-            sol_attr = sol_attr[index]
+        sol_attr = select(name, state.solution_ast)
     except IndexError:
         raise IndexError("Can't get %s attribute" % name)
 
@@ -141,9 +147,7 @@ def check_edge(
         _msg = MSG_CHECK_FALLBACK
 
     try:
-        stu_attr = getattr(state.student_ast, name)
-        if stu_attr and isinstance(stu_attr, list) and index is not None:
-            stu_attr = stu_attr[index]
+        stu_attr = select(name, state.student_ast)
     except:
         state.report(Feedback(_msg))
 
@@ -152,9 +156,6 @@ def check_edge(
         state.report(Feedback(_msg))
 
     return state.to_child(student_ast=stu_attr, solution_ast=sol_attr)
-
-
-import re
 
 
 def has_code(

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -90,9 +90,7 @@ def check_node(
             _msg = MSG_CHECK_FALLBACK
         state.report(Feedback(_msg))
 
-    return state.to_child(
-        student_ast=stu_stmt, solution_ast=sol_stmt
-    )
+    return state.to_child(student_ast=stu_stmt, solution_ast=sol_stmt)
 
 
 @requires_ast
@@ -153,9 +151,7 @@ def check_edge(
     if stu_attr is None and sol_attr is not None:
         state.report(Feedback(_msg))
 
-    return state.to_child(
-        student_ast=stu_attr, solution_ast=sol_attr
-    )
+    return state.to_child(student_ast=stu_attr, solution_ast=sol_attr)
 
 
 import re

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -69,7 +69,7 @@ def check_node(
             new_state = Ex().check_node('SelectStmt', 0)
 
     """
-    df = partial(state.ast_dispatcher, name, priority=priority)
+    df = partial(state.ast_dispatcher.find, name, priority=priority)
 
     sol_stmt_list = df(state.solution_ast)
     try:

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -142,7 +142,7 @@ def check_correct(state, check, diagnose):
     try:
         multi(state, diagnose)
     except TestFail as e:
-        if feedback is not None or state.force_diagnose:
+        if feedback is not None or getattr(state, "force_diagnose", False):
             feedback = e.feedback
 
     if feedback is not None:

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -36,7 +36,7 @@ def multi(state, *tests):
     return state
 
 
-@legacy_signature(incorrect_msg='msg')
+@legacy_signature(incorrect_msg="msg")
 def check_not(state, *tests, msg):
     """Run multiple subtests that should fail. If all subtests fail, returns original state (for chaining)
 

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -165,6 +165,7 @@ def get_checks_dict(checks_module):
         for k, v in vars(checks_module).items()
         if k not in builtins.__dict__
         if not k.startswith("__")
+        if callable(v)
     }
 
 

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -168,6 +168,15 @@ class ExGen:
 Ex = ExGen(None, {})
 
 
+def get_checks_dict(checks_module):
+    return {
+        k: v
+        for k, v in vars(checks_module).items()
+        if k not in builtins.__dict__
+        if not k.startswith("__")
+    }
+
+
 def create_sct_context(State, sct_dict, root_state=None):
     state_dec = state_dec_gen(State, sct_dict)
     sct_ctx = {k: state_dec(v) for k, v in sct_dict.items()}

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Union, List, Dict
+from typing import TypeVar, Generic, Union, List, Dict, Tuple
 from ast import NodeVisitor
 import inspect
 import importlib
@@ -54,7 +54,7 @@ class DispatcherInterface(Generic[T]):
         raise NotImplementedError
 
     def select(
-        self, path: Union[str, List[Union[str, int]]], node: T
+        self, path: Union[str, Tuple, List[Union[str, int]]], node: T
     ) -> Union[T, List[T]]:
         raise NotImplementedError
 

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -155,7 +155,7 @@ class Dispatcher(DispatcherInterface):
 
 
 def get_ord(num):
-    assert num != 0, "use strictly positive numbers in get_ord()"
+    assert num > 0, "use strictly positive numbers in get_ord()"
     nums = {
         1: "first",
         2: "second",
@@ -171,4 +171,6 @@ def get_ord(num):
     if num in nums:
         return nums[num]
     else:
-        return "%dth" % num
+        return (
+            {1: "{}st", 2: "{}nd", 3: "{}rd"}.get(num if (num < 20) else (num % 10), "{}th")
+        ).format(num)

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -34,7 +34,8 @@ class Selector(NodeVisitor):
                 return False
         else:
             if isinstance(node, self.target_cls) and (
-                    self.target_cls_name is None or self.target_cls_name == node.__class__.__name__
+                self.target_cls_name is None
+                or self.target_cls_name == node.__class__.__name__
             ):
                 return True
             else:
@@ -52,7 +53,9 @@ class DispatcherInterface(Generic[T]):
         # todo: document signature, strategy kwarg (depth/breadth first)
         raise NotImplementedError
 
-    def select(self, path: Union[str, List[Union[str, int]]], node: T) -> Union[T, List[T]]:
+    def select(
+        self, path: Union[str, List[Union[str, int]]], node: T
+    ) -> Union[T, List[T]]:
         raise NotImplementedError
 
     @staticmethod

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -53,9 +53,7 @@ class DispatcherInterface(Generic[T]):
         # todo: document signature, strategy kwarg (depth/breadth first)
         raise NotImplementedError
 
-    def select(
-        self, path: Union[str, Tuple, List[Union[str, int]]], node: T
-    ) -> Union[T, List[T]]:
+    def select(self, path: Union[str, Tuple], node: T) -> Union[T, List[T]]:
         raise NotImplementedError
 
     @staticmethod
@@ -102,11 +100,15 @@ class Dispatcher(DispatcherInterface):
 
         return selector.out
 
-    def select(self, path, node):
+    def select(self, spec, node):
         result = node
-        if isinstance(path, str):
-            path = self._path_str_to_list(path)
-        for step in path:
+        if isinstance(spec, tuple):
+            raise ValueError(
+                "This dispatcher currently doesn't support tuple specs for select"
+            )
+        if isinstance(spec, str):
+            spec = self._path_str_to_list(spec)
+        for step in spec:
             if isinstance(step, str):
                 result = getattr(result, step, None)
             elif isinstance(step, int):

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -52,9 +52,6 @@ class DispatcherInterface(Generic[T]):
         # todo: document signature, strategy kwarg (depth/breadth first)
         raise NotImplementedError
 
-    def select(self, path: str, node: T) -> Union[T, List[T]]:
-        raise NotImplementedError
-
     def parse(self, code: str):
         raise NotImplementedError
 

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -84,7 +84,7 @@ class Dispatcher(DispatcherInterface):
     def __init__(self, node_cls, nodes=None, ast_mod=None, safe_parsing=True):
         """Wrapper to instantiate and use a Selector using node names."""
         self.node_cls = node_cls
-        self.nodes = nodes or {}
+        self.nodes = nodes or getattr(ast_mod, "nodes", {})
         self.ast_mod = ast_mod
         self.safe_parsing = safe_parsing
 

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -10,7 +10,7 @@ def _debug(state, msg=""):
     """
     check_history = [
         s.creator["type"]
-        for s in state.get_state_history()
+        for s in state.state_history
         if getattr(s, "creator", None)
     ]
 

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -19,7 +19,7 @@ def _debug(state, msg=""):
         feedback += msg + "\n"
 
     if check_history:
-        feedback += "SCT function history: `{}`".format(" > ".join(check_history))
+        feedback += "SCT function zoom history: `{}`".format(" > ".join(check_history))
 
     if state.reporter.tests:
         feedback += "\nLast test: `{}`".format(repr(state.reporter.tests[-1]))

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -1,5 +1,34 @@
 from functools import wraps
 
+from protowhat.Feedback import Feedback
+
+
+def _debug(state, msg=""):
+    """
+    This SCT function makes the SCT fail with a message containing debugging information
+    and highlights the focus of the SCT at that point.
+    """
+    check_history = [
+        s.creator["type"]
+        for s in state.get_state_history()
+        if getattr(s, "creator", None)
+    ]
+
+    feedback = ""
+    if msg:
+        feedback += msg + "\n"
+
+    if check_history:
+        feedback += "SCT function history: `{}`".format(" > ".join(check_history))
+
+    if state.reporter.tests:
+        feedback += "\nLast test: `{}`".format(repr(state.reporter.tests[-1]))
+
+    # latest highlight added automatically
+    state.report(Feedback(feedback))
+
+    return state
+
 
 def legacy_signature(**kwargs_mapping):
     """

--- a/protowhat/utils_ast.py
+++ b/protowhat/utils_ast.py
@@ -52,7 +52,7 @@ class AstNode(AST):
     _fields = ()
     _priority = 1
 
-    def get_text(self, text):
+    def get_text(self, full_text=None):
         raise NotImplementedError()
 
     def get_position(self):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,24 @@
+from protowhat.Reporter import Reporter
+from protowhat.State import State
+from protowhat.Test import Test
+
+
+class Success(Test):
+    def test(self):
+        self.result = True
+
+
+def state():
+    return State("student_code", "", "", None, None, {}, {}, Reporter())
+
+
+def noop(state):
+    return state
+
+
+def child_state(state):
+    return state.to_child()
+
+
+def dummy_checks():
+    return {"noop": noop, "child_state": child_state}

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -3,12 +3,8 @@ from collections import Counter
 import pytest
 from protowhat.Feedback import Feedback
 from protowhat.Reporter import Reporter
-from protowhat.Test import Test as T, Fail
-
-
-class Success(T):
-    def test(self):
-        self.result = True
+from protowhat.Test import Fail
+from tests.helper import Success
 
 
 def test_test_runner_proxy():

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -37,14 +37,16 @@ def test_test_runner_proxy():
 
 
 highlight_range_1 = {"line_start": 1, "column_start": 3, "line_end": 5, "column_end": 7}
+highlight_payload_1 = {"line_start": 1, "column_start": 4, "line_end": 5, "column_end": 8}
 highlight_range_2 = {
     "line_start": 3,
     "column_start": 5,
     "line_end": 7,
     "column_end": 11,
 }
+highlight_payload_2 = {"line_start": 3, "column_start": 6, "line_end": 7, "column_end": 12}
 highlight_combined = Counter()
-highlight_combined.update(highlight_range_1)
+highlight_combined.update(highlight_payload_1)
 highlight_combined.update(highlight_range_2)
 
 
@@ -52,22 +54,19 @@ class FeedbackTest(Feedback):
     def _highlight_data(self):
         return self.highlight
 
-    def get_highlight_info(self):
-        return self.get_highlight_data()
-
 
 @pytest.mark.parametrize(
     "offset, highlight, payload_highlight_info",
     [
         (None, {}, {}),
-        (None, highlight_range_1, highlight_range_1),
+        (None, highlight_range_1, highlight_payload_1),
         ({}, {}, {}),
-        ({}, highlight_range_1, highlight_range_1),
+        ({}, highlight_range_1, highlight_payload_1),
         (highlight_range_1, {}, {}),
         (
             {"line_start": 1},
             highlight_range_1,
-            {**highlight_range_1, "line_start": 2, "line_end": 6},
+            {**highlight_payload_1, "line_start": 2, "line_end": 6},
         ),
         (highlight_range_2, highlight_range_1, highlight_combined),
     ],

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,102 @@
+from collections import Counter
+
+import pytest
+from protowhat.Feedback import Feedback
+from protowhat.Reporter import Reporter
+from protowhat.Test import Test as T, Fail
+
+
+class Success(T):
+    def test(self):
+        self.result = True
+
+
+def test_test_runner_proxy():
+    r = Reporter()
+
+    assert len(r.tests) == 0
+    assert not r.has_failed
+    assert not r.failures
+
+    result, feedback = r.do_test(Success("msg"))
+
+    assert len(r.tests) == 1
+    assert not r.has_failed
+    assert not r.failures
+    assert isinstance(result, bool)
+    assert feedback is None
+
+    failing_test = Fail("msg")
+    results = r.do_tests([failing_test, Success("msg")])
+
+    assert len(r.tests) == 3
+    assert r.has_failed
+    assert len(r.failures) == 1
+    assert failing_test in r.failures
+    assert isinstance(results, list)
+
+    assert r.tests == r.runner.tests
+    assert r.runner.has_failed
+    assert r.failures == r.runner.failures
+
+
+highlight_range_1 = {"line_start": 1, "column_start": 3, "line_end": 5, "column_end": 7}
+highlight_range_2 = {
+    "line_start": 3,
+    "column_start": 5,
+    "line_end": 7,
+    "column_end": 11,
+}
+highlight_combined = Counter()
+highlight_combined.update(highlight_range_1)
+highlight_combined.update(highlight_range_2)
+
+
+class FeedbackTest(Feedback):
+    def _highlight_data(self):
+        return self.highlight
+
+    def get_highlight_info(self):
+        return self.get_highlight_data()
+
+
+@pytest.mark.parametrize(
+    "offset, highlight, payload_highlight_info",
+    [
+        (None, {}, {}),
+        (None, highlight_range_1, highlight_range_1),
+        ({}, {}, {}),
+        ({}, highlight_range_1, highlight_range_1),
+        (highlight_range_1, {}, {}),
+        (
+            {"line_start": 1},
+            highlight_range_1,
+            {**highlight_range_1, "line_start": 2, "line_end": 6},
+        ),
+        (highlight_range_2, highlight_range_1, highlight_combined),
+    ],
+)
+def test_highlighting_offset(offset, highlight, payload_highlight_info):
+    r = Reporter(highlight_offset=offset)
+
+    f = FeedbackTest("msg")
+    f.highlight = highlight
+
+    payload = r.build_failed_payload(f)
+
+    expected_payload = {"correct": False, "message": "msg", **payload_highlight_info}
+
+    assert payload == expected_payload
+
+
+def test_highlighting_offset_proxy():
+    r = Reporter(Reporter(), highlight_offset=highlight_range_2)
+
+    f = FeedbackTest("msg")
+    f.highlight = highlight_range_1
+
+    payload = r.build_failed_payload(f)
+
+    expected_payload = {"correct": False, "message": "msg", **highlight_combined}
+
+    assert payload == expected_payload

--- a/tests/test_sct_syntax.py
+++ b/tests/test_sct_syntax.py
@@ -148,3 +148,31 @@ def test_sct_context_creation(state, test_checks):
     for chain in ["Ex", "F"]:
         assert chain in sct_ctx
         assert isinstance(sct_ctx[chain](state), Chain)
+
+
+def test_state_linking_root_creator(state):
+    def diagnose(end_state):
+        assert end_state.creator is None
+
+    f = F(attr_scts={"diagnose": diagnose})
+    Ex(state) >> f.diagnose()
+
+
+def test_state_linking_root_creator_noop(state, test_checks):
+    def diagnose(end_state):
+        assert end_state.creator is None
+
+    TestEx = ExGen(state, test_checks)
+    TestEx().noop() >> F(attr_scts={"diagnose": diagnose}).diagnose()
+
+
+def test_state_linking_root_creator_child_state(state, test_checks):
+    def diagnose(end_state):
+        assert end_state != state
+        assert end_state.parent_state is state
+        assert len(end_state.state_history) == 2
+        assert state == end_state.state_history[0]
+        assert end_state == end_state.state_history[1]
+
+    TestEx = ExGen(state, test_checks)
+    TestEx().child_state() >> F(attr_scts={"diagnose": diagnose}).diagnose()

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,16 +1,18 @@
 import pytest
 
-from protowhat.selectors import Selector, get_ord
+from protowhat.selectors import Selector, get_ord, DispatcherInterface, Dispatcher
+
+# use python's builtin ast library
+from ast import AST, Expr, Num
+Num._priority = 1
 
 
-def test_selector_standalone():
-    # use python's builtin ast library
-    from ast import Expr, Num
+@pytest.fixture
+def node():
+    return Expr(value=Num(n=1))
 
-    Expr._priority = 0
-    Num._priority = 1
-    node = Expr(value=Num(n=1))
 
+def test_selector_standalone(node):
     sel = Selector(Num)
     sel.visit(node)
     assert isinstance(sel.out[0], Num)
@@ -22,6 +24,30 @@ def test_selector_standalone():
     sel = Selector(Expr)
     sel.visit(node, head=True)
     assert len(sel.out) == 0
+
+
+@pytest.mark.parametrize(
+    "path_str, path_list",
+    [
+        ("", []),
+        ("a", ["a"]),
+        ("a.", ["a"]),
+        ("1", [1]),
+        ("a.0", ["a", 0]),
+        ("a.b.c", ["a", "b", "c"]),
+        ("a.2.c", ["a", 2, "c"]),
+    ],
+)
+def test_dispatcher_path_str_to_list(path_str, path_list):
+    assert DispatcherInterface._path_str_to_list(path_str) == path_list
+
+
+def test_dispatcher_find(node):
+    assert isinstance(Dispatcher(AST).find("Num", node)[0], Num)
+
+
+def test_dispatcher_select(node):
+    assert isinstance(Dispatcher(AST).select("value", node), Num)
 
 
 @pytest.mark.parametrize("num, ord", [(1, "first"), (12, "12th"), (23, "23rd")])

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,4 +1,6 @@
-from protowhat.selectors import Selector
+import pytest
+
+from protowhat.selectors import Selector, get_ord
 
 
 def test_selector_standalone():
@@ -20,3 +22,8 @@ def test_selector_standalone():
     sel = Selector(Expr)
     sel.visit(node, head=True)
     assert len(sel.out) == 0
+
+
+@pytest.mark.parametrize("num, ord", [(1, "first"), (12, "12th"), (23, "23rd")])
+def test_ord(num, ord):
+    assert get_ord(num) == ord

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,24 @@
-from protowhat.utils import legacy_signature
+import pytest
+
+from tests.helper import Success, state, dummy_checks
+from protowhat.Test import TestFail as TF
+from protowhat.sct_syntax import ExGen, F
+from protowhat.utils import legacy_signature, _debug
+
+state = pytest.fixture(state)
+dummy_checks = pytest.fixture(dummy_checks)
+
+
+def test_debug(state, dummy_checks):
+    state.do_test(Success("msg"))
+    Ex = ExGen(state, dummy_checks)
+    try:
+        Ex().noop().child_state() >> F(attr_scts={"_debug": _debug})._debug("breakpoint name")
+    except TF as e:
+        assert "breakpoint name" in str(e)
+        assert "history" in str(e)
+        assert "child_state" in str(e)
+        assert "test" in str(e)
 
 
 def test_legacy_signature():


### PR DESCRIPTION
These updates support a sheetwhat refactor, but can be used in other xwhat libraries as well (especially `link_to_state`).

- Make dedicated `TestRunner`
	- `Reporter` inherits from `TestRunner`
	- Add `TestRunnerProxy` that allows checks to run and manage multiple tests
- Link check and state history with `link_to_state`
- Extend `Dispatcher` with `select` (~ check edge with a path)

**TODO:**
Decide whether `link_to_state` should be used in the chain classes or as a decorator applied to the check functions:

- The first option requires to decorate the functions when used without the chains (now mostly in tests)
- The second option requires adding it to all check functions

Decision: first option

~Add tests~