### PR TITLE
No numpy

### DIFF
--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -8,7 +8,20 @@ class Feedback:
             self.highlighting_disabled = state.highlighting_disabled
 
     def _highlight_data(self):
-        return self.highlight.get_position()
+        if hasattr(self.highlight, "get_position"):
+            return self.highlight.get_position()
+        elif hasattr(self.highlight, "first_token") and hasattr(
+            self.highlight, "last_token"
+        ):
+            # used by pythonwhat
+            # a plugin+register system would be better
+            # if many different AST interfaces exist
+            return {
+                "line_start": self.highlight.first_token.start[0],
+                "column_start": self.highlight.first_token.start[1],
+                "line_end": self.highlight.last_token.end[0],
+                "column_end": self.highlight.last_token.end[1],
+            }
 
     def get_highlight_data(self):
         result = None

--- a/protowhat/Reporter.py
+++ b/protowhat/Reporter.py
@@ -65,6 +65,7 @@ class Reporter(TestRunnerProxy):
 
     def __init__(self, runner=None, errors=None, highlight_offset=None):
         super().__init__(runner or TestRunner())
+        self.fail = False
         self.errors = errors
         self.errors_allowed = False
         self.highlight_offset = highlight_offset or {}
@@ -94,7 +95,7 @@ class Reporter(TestRunnerProxy):
         }
 
     def build_final_payload(self):
-        if self.errors and not self.errors_allowed:
+        if self.fail or self.errors and not self.errors_allowed:
             feedback_msg = "Your code generated an error. Fix it and try again!"
             return {"correct": False, "message": Reporter.to_html(feedback_msg)}
         else:

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -71,7 +71,7 @@ class State:
                 result = self.ast_dispatcher.parse(text)
             except self.ast_dispatcher.ParseError as e:
                 if test:
-                    self.report(Feedback(e.message))
+                    self.report(e.message)
                 else:
                     raise InstructorError(
                         "Something went wrong when parsing PEC or solution code: %s"
@@ -125,10 +125,11 @@ class State:
         except StopIteration:
             return self.ast_dispatcher.describe(self.student_ast, "{node_name}")
 
-    def report(self, feedback: Feedback):
-        if feedback.highlight is None and self is not getattr(self, "root_state", None):
-            feedback.highlight = self.student_ast
-        test = Fail(feedback)
+    def report(self, feedback: str):
+        test_feedback = Feedback(feedback, self)
+        if test_feedback.highlight is None and self is not getattr(self, "root_state", None):
+            test_feedback.highlight = self.student_ast
+        test = Fail(test_feedback)
 
         return self.do_test(test)
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -127,7 +127,9 @@ class State:
 
     def report(self, feedback: str):
         test_feedback = Feedback(feedback, self)
-        if test_feedback.highlight is None and self is not getattr(self, "root_state", None):
+        if test_feedback.highlight is None and self is not getattr(
+            self, "root_state", None
+        ):
             test_feedback.highlight = self.student_ast
         test = Fail(test_feedback)
 

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -4,6 +4,7 @@ from jinja2 import Template
 from protowhat.selectors import DispatcherInterface
 from protowhat.Feedback import Feedback, InstructorError
 from protowhat.Test import Fail, Test, TestFail
+from protowhat.utils import _debug
 
 
 class DummyDispatcher(DispatcherInterface):
@@ -134,6 +135,9 @@ class State:
     def do_test(self, test: Test):
         result, feedback = self.reporter.do_test(test)
         if result is False:
+            if getattr(self, "debug", False):
+                setattr(self, "debug", False)  # prevent loop
+                _debug(self)
             raise TestFail(feedback, self.reporter.build_failed_payload(feedback))
         return result, feedback
 

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -1,5 +1,4 @@
 from protowhat.Feedback import Feedback
-import numpy as np
 
 
 class TestFail(Exception):
@@ -47,7 +46,7 @@ class Test:
         if self.result is None:
             try:
                 self.test()
-                self.result = bool(np.array(self.result).all())
+                self.result = bool(self.result)
             except:
                 self.result = False
 

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -59,6 +59,9 @@ class Test:
     def get_feedback(self):
         return self.feedback
 
+    def __repr__(self):
+        return "{} {}".format(self.__class__.__name__, str(vars(self)))
+
 
 class Fail(Test):
     def test(self):

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -18,9 +18,9 @@ def check_file(
 
     p = Path(path)
     if not p.exists():
-        state.report(Feedback(missing_msg.format(path)))  # test file exists
+        state.report(missing_msg.format(path))  # test file exists
     if p.is_dir():
-        state.report(Feedback(is_dir_msg.format(path)))  # test its not a dir
+        state.report(is_dir_msg.format(path))  # test its not a dir
 
     code = p.read_text()
 
@@ -41,7 +41,7 @@ def check_file(
 def has_dir(state, path, incorrect_msg="Did you create a directory `{}`?"):
     """Test whether a directory exists."""
     if not Path(path).is_dir():
-        state.report(Feedback(incorrect_msg.format(path)))
+        state.report(incorrect_msg.format(path))
 
     return state
 

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -127,6 +127,7 @@ def check_edge(
             clause =  select.check_edge('from_clause', None)    # get from_clause (a list)
             clause2 = select.check_edge('from_clause', 0)       # get first entry in from_clause
     """
+
     def select(node_name, node):
         attr = state.ast_dispatcher.select(node_name, node)
         if attr and isinstance(attr, list) and index is not None:

--- a/protowhat/checks/check_funcs.py
+++ b/protowhat/checks/check_funcs.py
@@ -90,7 +90,7 @@ def check_node(
         )
         if _msg is None:
             _msg = MSG_CHECK_FALLBACK
-        state.report(Feedback(_msg))
+        state.report(_msg)
 
     return state.to_child(student_ast=stu_stmt, solution_ast=sol_stmt)
 
@@ -149,11 +149,11 @@ def check_edge(
     try:
         stu_attr = select(name, state.student_ast)
     except:
-        state.report(Feedback(_msg))
+        state.report(_msg)
 
     # fail if attribute exists, but is none only for student
     if stu_attr is None and sol_attr is not None:
-        state.report(Feedback(_msg))
+        state.report(_msg)
 
     return state.to_child(student_ast=stu_attr, solution_ast=sol_attr)
 
@@ -227,7 +227,7 @@ def has_code(
     res = text in stu_text if fixed else re.search(text, stu_text)
 
     if not res:
-        state.report(Feedback(_msg))
+        state.report(_msg)
 
     return state
 
@@ -304,7 +304,7 @@ def has_equal_ast(
         else "Something is missing.",
     )
     if (exact and (sol_rep != stu_rep)) or (not exact and (sol_rep not in stu_rep)):
-        state.report(Feedback(_msg))
+        state.report(_msg)
 
     return state
 
@@ -312,6 +312,6 @@ def has_equal_ast(
 def has_parsed_ast(state):
     asts = [state.student_ast, state.solution_ast]
     if any(isinstance(c, state.ast_dispatcher.ParseError) for c in asts):
-        state.report(Feedback("AST did not parse"))
+        state.report("AST did not parse")
 
     return state

--- a/protowhat/checks/check_logic.py
+++ b/protowhat/checks/check_logic.py
@@ -1,5 +1,5 @@
 from protowhat.Feedback import Feedback
-from protowhat.Test import TestFail
+from protowhat.Test import TestFail, Fail
 from functools import partial
 
 from protowhat.utils import legacy_signature
@@ -68,7 +68,7 @@ def check_not(state, *tests, msg):
         except TestFail:
             # it fails, as expected, off to next one
             continue
-        return state.report(Feedback(msg))
+        return state.report(msg)
 
     # return original state, so can be chained
     return state
@@ -111,7 +111,7 @@ def check_or(state, *tests):
         if success:
             return state  # todo: add test
 
-    state.report(first_feedback)
+    state.do_test(Fail(first_feedback))
 
 
 def check_correct(state, check, diagnose):
@@ -146,7 +146,7 @@ def check_correct(state, check, diagnose):
             feedback = e.feedback
 
     if feedback is not None:
-        state.report(feedback)
+        state.do_test(Fail(feedback))
 
     return state  # todo: add test
 
@@ -180,6 +180,6 @@ def fail(state, msg="fail"):
     For example, failing a test will highlight the code as if the previous test/check had failed.
     """
     _msg = state.build_message(msg)
-    state.report(Feedback(_msg, state))
+    state.report(_msg)
 
     return state

--- a/protowhat/checks/check_simple.py
+++ b/protowhat/checks/check_simple.py
@@ -20,7 +20,7 @@ def has_chosen(state, correct, msgs):
     exec(state.student_code, globals(), ctxt)
     sel_indx = ctxt["selected_option"]
     if sel_indx != correct:
-        state.report(Feedback(msgs[sel_indx - 1]))
+        state.report(msgs[sel_indx - 1])
     else:
         state.reporter.success_msg = msgs[correct - 1]
 

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -25,7 +25,11 @@ def link_to_state(check):
     @wraps(check)
     def wrapper(state, *args, **kwargs):
         new_state = check(state, *args, **kwargs)
-        if new_state != state and hasattr(new_state, "creator") and not isinstance(check, F):
+        if (
+            new_state != state
+            and hasattr(new_state, "creator")
+            and not isinstance(check, F)
+        ):
             ba = inspect.signature(check).bind(state, *args, **kwargs)
             ba.apply_defaults()
             new_state.creator = {"type": check.__name__, "args": ba.arguments}

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -26,7 +26,7 @@ def _debug(state, msg="", on_error=False):
 
     if not on_error:
         # latest highlight added automatically
-        state.report(Feedback(feedback))
+        state.report(feedback)
     else:
         # debug on next failure
         state.debug = True

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -3,7 +3,7 @@ from functools import wraps
 from protowhat.Feedback import Feedback
 
 
-def _debug(state, msg=""):
+def _debug(state, msg="", on_error=False):
     """
     This SCT function makes the SCT fail with a message containing debugging information
     and highlights the focus of the SCT at that point.
@@ -24,8 +24,14 @@ def _debug(state, msg=""):
     if state.reporter.tests:
         feedback += "\nLast test: `{}`".format(repr(state.reporter.tests[-1]))
 
-    # latest highlight added automatically
-    state.report(Feedback(feedback))
+    if not on_error:
+        # latest highlight added automatically
+        state.report(Feedback(feedback))
+    else:
+        # debug on next failure
+        state.debug = True
+        # or at the end (to prevent debug mode in production)
+        state.reporter.fail = True
 
     return state
 

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -19,7 +19,7 @@ def _debug(state, msg=""):
         feedback += msg + "\n"
 
     if check_history:
-        feedback += "SCT function zoom history: `{}`".format(" > ".join(check_history))
+        feedback += "SCT function state history: `{}`".format(" > ".join(check_history))
 
     if state.reporter.tests:
         feedback += "\nLast test: `{}`".format(repr(state.reporter.tests[-1]))

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -9,9 +9,7 @@ def _debug(state, msg="", on_error=False):
     and highlights the focus of the SCT at that point.
     """
     check_history = [
-        s.creator["type"]
-        for s in state.state_history
-        if getattr(s, "creator", None)
+        s.creator["type"] for s in state.state_history if getattr(s, "creator", None)
     ]
 
     feedback = ""

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from setuptools import setup
 
 PACKAGE_NAME = "protowhat"
 REQUIREMENT_NAMES = ["markdown2", "jinja2"]
-PEER_REQUIREMENTS = ["numpy"]
 
 HERE = path.abspath(path.dirname(__file__))
 VERSION_FILE = path.join(HERE, PACKAGE_NAME, "__init__.py")
@@ -23,7 +22,7 @@ with open(REQUIREMENTS_FILE, encoding="utf-8") as fp:
     REQUIREMENTS = [
         re.search(_requirements_re_template.format(requirement), req_txt, re.M).group(0)
         for requirement in REQUIREMENT_NAMES
-    ] + PEER_REQUIREMENTS
+    ]
 with open(README_FILE, encoding="utf-8") as fp:
     README = fp.read()
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -22,7 +22,7 @@ def child_state(state):
 
 
 def fail(state):
-    state.report(Feedback("Fail"))
+    state.report("Fail")
 
 
 def dummy_checks():

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,3 +1,4 @@
+from protowhat.Feedback import Feedback
 from protowhat.Reporter import Reporter
 from protowhat.State import State
 from protowhat.Test import Test
@@ -20,5 +21,9 @@ def child_state(state):
     return state.to_child()
 
 
+def fail(state):
+    state.report(Feedback("Fail"))
+
+
 def dummy_checks():
-    return {"noop": noop, "child_state": child_state}
+    return {"noop": noop, "child_state": child_state, "fail": fail}

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -37,14 +37,24 @@ def test_test_runner_proxy():
 
 
 highlight_range_1 = {"line_start": 1, "column_start": 3, "line_end": 5, "column_end": 7}
-highlight_payload_1 = {"line_start": 1, "column_start": 4, "line_end": 5, "column_end": 8}
+highlight_payload_1 = {
+    "line_start": 1,
+    "column_start": 4,
+    "line_end": 5,
+    "column_end": 8,
+}
 highlight_range_2 = {
     "line_start": 3,
     "column_start": 5,
     "line_end": 7,
     "column_end": 11,
 }
-highlight_payload_2 = {"line_start": 3, "column_start": 6, "line_end": 7, "column_end": 12}
+highlight_payload_2 = {
+    "line_start": 3,
+    "column_start": 6,
+    "line_end": 7,
+    "column_end": 12,
+}
 highlight_combined = Counter()
 highlight_combined.update(highlight_payload_1)
 highlight_combined.update(highlight_range_2)

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -4,6 +4,7 @@ from protowhat.selectors import Selector, get_ord, DispatcherInterface, Dispatch
 
 # use python's builtin ast library
 from ast import AST, Expr, Num
+
 Num._priority = 1
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,10 @@ def test_debug(state, dummy_checks):
     state.do_test(Success("msg"))
     Ex = ExGen(state, dummy_checks)
     try:
-        Ex().noop().child_state() >> F(attr_scts={"_debug": _debug})._debug("breakpoint name")
+        Ex().noop().child_state() >> F(attr_scts={"_debug": _debug})._debug(
+            "breakpoint name"
+        )
+        assert False
     except TF as e:
         assert "breakpoint name" in str(e)
         assert "history" in str(e)
@@ -25,6 +28,7 @@ def test_delayed_debug(state, dummy_checks):
     Ex = ExGen(state, {"_debug": _debug, **dummy_checks})
     try:
         Ex()._debug("breakpoint name", on_error=True).noop().child_state().fail()
+        assert False
     except TF as e:
         assert "history" in str(e)
         assert "child_state" in str(e)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,22 @@ def test_debug(state, dummy_checks):
         assert "test" in str(e)
 
 
+def test_delayed_debug(state, dummy_checks):
+    Ex = ExGen(state, {"_debug": _debug, **dummy_checks})
+    try:
+        Ex()._debug("breakpoint name", on_error=True).noop().child_state().fail()
+    except TF as e:
+        assert "history" in str(e)
+        assert "child_state" in str(e)
+        assert "test" in str(e)
+
+
+def test_final_debug(state, dummy_checks):
+    Ex = ExGen(state, {"_debug": _debug, **dummy_checks})
+    Ex()._debug("breakpoint name", on_error=True).noop().child_state()
+    assert state.reporter.fail
+
+
 def test_legacy_signature():
     @legacy_signature(old_arg1="arg1", old_arg2="arg2")
     def func(arg1, arg2=1):


### PR DESCRIPTION
Numpy has to be installed for the used Python version, which is determined by the base image, so installing numpy in the shared image doesn't work with all courses.
The conversion was ported from pythonwhat, but isn't necessary in protowhat, so it's moved back to pythonwhat.