### PR TITLE
Improve check_file

### DIFF
--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -59,6 +59,7 @@ class State:
             self.ast_dispatcher = self.get_dispatcher()
 
         # Parse solution and student code
+        # if possible, not done yet and wanted (ast arguments not False)
         if isinstance(self.solution_code, str) and self.solution_ast is None:
             self.solution_ast = self.parse(self.solution_code, test=False)
         if isinstance(self.student_code, str) and self.student_ast is None:

--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from protowhat.Feedback import Feedback
-
 
 def check_file(
     state,
@@ -16,24 +14,24 @@ def check_file(
     Note: this SCT fails if the file is a directory.
     """
 
-    p = Path(path)
-    if not p.exists():
+    path_obj = Path(path)
+    if not path_obj.exists():
         state.report(missing_msg.format(path))  # test file exists
-    if p.is_dir():
+    if path_obj.is_dir():
         state.report(is_dir_msg.format(path))  # test its not a dir
 
-    code = p.read_text()
+    code = get_file_content(path_obj)
 
     sol_kwargs = {"solution_code": solution_code, "solution_ast": None}
     if solution_code:
         sol_kwargs["solution_ast"] = (
-            state.parse(solution_code, test=False) if parse else None
+            state.parse(solution_code, test=False) if parse else False
         )
 
     return state.to_child(
         append_message="We checked the file `{}`. ".format(path),
         student_code=code,
-        student_ast=state.parse(code) if parse else None,
+        student_ast=state.parse(code) if parse else False,
         **sol_kwargs
     )
 
@@ -50,6 +48,18 @@ def has_dir(state, path, incorrect_msg="Did you create a directory `{}`?"):
 def load_file(relative_path, prefix=""):
     # the prefix can be partialed
     # so it's not needed to copy the common part of paths
-    p = Path(prefix, relative_path)
+    path = Path(prefix, relative_path)
 
-    return p.read_text()
+    return get_file_content(path)
+
+
+def get_file_content(path):
+    if not isinstance(path, Path):
+        path = Path(path)
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except:
+        content = None
+
+    return content

--- a/protowhat/sct_syntax.py
+++ b/protowhat/sct_syntax.py
@@ -63,7 +63,7 @@ class Chain:
             self._double_attr_error()
         else:
             # make a copy to return,
-            # in case someone does: a = chain.a; b = chain.b
+            # in case someone does: chain = chain_of_checks; chain.a; chain.b
             return self._sct_copy(attr_scts[attr])
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
- support unicode
- disable ast parsing, by setting properties to `False` (using `None`, xwhat will just parse it later)