### PR TITLE
Add shared allow_errors and improve repr

### DIFF
--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -33,6 +33,9 @@ class Feedback:
 
         return result or {}
 
+    def __repr__(self):
+        return "<{} {}>".format(self.__class__.__name__, repr(vars(self)))
+
 
 class InstructorError(Exception):
     pass

--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -48,6 +48,7 @@ class State:
     ):
         args = locals().copy()
         self.params = list()
+
         for k, v in args.items():
             if k != "self":
                 self.params.append(k)

--- a/protowhat/Test.py
+++ b/protowhat/Test.py
@@ -60,7 +60,7 @@ class Test:
         return self.feedback
 
     def __repr__(self):
-        return "{} {}".format(self.__class__.__name__, str(vars(self)))
+        return "<{} {}>".format(self.__class__.__name__, repr(vars(self)))
 
 
 class Fail(Test):

--- a/protowhat/checks/check_simple.py
+++ b/protowhat/checks/check_simple.py
@@ -27,6 +27,23 @@ def has_chosen(state, correct, msgs):
     return state
 
 
+def allow_errors(state):
+    """
+    Allow running the student code to generate errors.
+
+    This has to be used only once for every time code is executed or a different xwhat library is used.
+    In most exercises that means it should be used just once.
+
+    :Example:
+        The following SCT allows the student code to generate errors::
+
+            Ex().allow_errors()
+    """
+    state.reporter.allow_errors()
+
+    return state
+
+
 def success_msg(state, msg):
     """
     Changes the success message to display if submission passes.

--- a/tests/test_sct_syntax.py
+++ b/tests/test_sct_syntax.py
@@ -118,7 +118,7 @@ def test_sct_dict_creation():
 
     sct_dict = get_checks_dict(check_simple)
 
-    assert len(sct_dict) == 3  # Feedback is also callable
+    assert len(sct_dict) == 4  # Feedback is also callable
     assert sct_dict["has_chosen"] == check_simple.has_chosen
     assert sct_dict["success_msg"] == check_simple.success_msg
 


### PR DESCRIPTION
- `allow_errors` can be used to allow errors for a nested SCT library or a nested run context (e.g. the new pythonwhat `run`
- the better `repr` methods will make the `_debug` output more useful