### PR TITLE
[CX-1180] feat: embed helpers

### DIFF
--- a/protowhat/State.py
+++ b/protowhat/State.py
@@ -4,7 +4,7 @@ from jinja2 import Template
 from protowhat.selectors import DispatcherInterface
 from protowhat.Feedback import Feedback, InstructorError
 from protowhat.Test import Fail, Test, TestFail
-from protowhat.utils import _debug
+from protowhat.utils import _debug, parameters_attr
 
 
 class DummyDispatcher(DispatcherInterface):
@@ -27,6 +27,7 @@ class DummyDispatcher(DispatcherInterface):
         return "code"
 
 
+@parameters_attr
 class State:
     def __init__(
         self,
@@ -47,11 +48,9 @@ class State:
         ast_dispatcher=None,
     ):
         args = locals().copy()
-        self.params = list()
 
         for k, v in args.items():
             if k != "self":
-                self.params.append(k)
                 setattr(self, k, v)
 
         self.messages = messages if messages else []
@@ -156,9 +155,11 @@ class State:
     def to_child(self, append_message="", **kwargs):
         """Basic implementation of returning a child state"""
 
-        bad_pars = set(kwargs) - set(self.params)
-        if bad_pars:
-            raise ValueError("Invalid init params for State: %s" % ", ".join(bad_pars))
+        bad_parameters = set(kwargs) - set(self.parameters)
+        if bad_parameters:
+            raise ValueError(
+                "Invalid init parameters for State: %s" % ", ".join(bad_parameters)
+            )
 
         child = copy(self)
         for k, v in kwargs.items():

--- a/protowhat/utils.py
+++ b/protowhat/utils.py
@@ -1,4 +1,7 @@
+import itertools
 from functools import wraps
+from inspect import signature, Parameter
+from typing import Type, Iterator, Callable, Dict
 
 
 def _debug(state, msg="", on_error=False):
@@ -32,17 +35,63 @@ def _debug(state, msg="", on_error=False):
     return state
 
 
-def legacy_signature(**kwargs_mapping):
+def get_class_parameters(cls: Type) -> Iterator[str]:
+    """
+    Get an iterator over all arguments that can be used to construct a class.
+
+    This works for class hierarchies that have compatible constructors.
+
+    Args:
+        cls: class to inspect constructor parameters in class hierarchy for
+
+    Returns:
+        Iterator over parameter names
+    """
+    return itertools.chain(
+        *(get_class_parameters(cls) for cls in cls.__bases__),
+        (
+            name
+            for name, param in signature(cls).parameters.items()
+            if param.kind is not Parameter.VAR_POSITIONAL
+            and param.kind is not Parameter.VAR_KEYWORD
+        )
+    )
+
+
+def parameters_attr(cls: Type) -> Type:
+    """Add a parameters attribute to the class with all arguments that can be used to construct it.
+
+    Why?
+    - calculated once: not manual list, not built every init
+    - accessible on class: not only usable on instances
+    - set difference between vars() and parameters doesn't include this class attribute
+    - more noticeable than manually setting attribute after class definition
+
+    Args:
+        cls: class to add parameters attribute to
+
+    Returns:
+        cls: modified class
+    """
+    cls.parameters = list(get_class_parameters(cls))
+    return cls
+
+
+def legacy_signature(
+    **kwargs_mapping: Dict[str, str]
+) -> Callable[[Callable], Callable]:
     """
     This decorator makes it possible to call a function using old argument names
     when they are passed as keyword arguments.
 
-    @legacy_signature(old_arg1='arg1', old_arg2='arg2')
-    def func(arg1, arg2=1):
-        return arg1 + arg2
+    :Example:
 
-    func(old_arg1=1) == 2
-    func(old_arg1=1, old_arg2=2) == 3
+        @legacy_signature(old_arg1='arg1', old_arg2='arg2')
+        def func(arg1, arg2=1):
+            return arg1 + arg2
+
+        func(old_arg1=1) == 2
+        func(old_arg1=1, old_arg2=2) == 3
     """
 
     def signature_decorator(f):

--- a/tests/test_sct_syntax.py
+++ b/tests/test_sct_syntax.py
@@ -10,6 +10,9 @@ from protowhat.sct_syntax import (
     get_checks_dict,
     create_sct_context,
     Chain,
+    create_embed_state,
+    create_embed_context,
+    get_embed_chain_constructors,
 )
 
 state = pytest.fixture(state)
@@ -107,35 +110,117 @@ def test_state_dec_instant_eval(state):
     assert stu_code(state) == "student_codex"
 
 
-def test_sct_dict_creation():
+def test_get_checks_dict_package():
+    # Given
     from protowhat import checks
 
+    # When
     sct_dict = get_checks_dict(checks)
+
+    # Then
     assert isinstance(sct_dict, dict)
     assert sct_dict == {
         str(sct.__name__): sct
         for sct in [checks.get_bash_history, checks.update_bash_history_info]
     }  # other checks not exported in init
 
+
+def test_get_checks_dict_module():
+    # Given
     from protowhat.checks import check_simple
 
+    # When
     sct_dict = get_checks_dict(check_simple)
 
+    # Then
     assert len(sct_dict) == 3
     assert sct_dict["has_chosen"] == check_simple.has_chosen
     assert sct_dict["success_msg"] == check_simple.success_msg
 
 
-def test_sct_context_creation(state, dummy_checks):
-    sct_ctx = create_sct_context(State, dummy_checks)
+def test_create_sct_context(state, dummy_checks):
+    # When
+    sct_ctx = create_sct_context(State, dummy_checks, state)
 
-    for check in ["noop", "child_state"]:
+    # Then
+    assert "state_dec" in sct_ctx
+
+    for check in dummy_checks:
         assert check in sct_ctx
         assert callable(sct_ctx[check])
 
     for chain in ["Ex", "F"]:
         assert chain in sct_ctx
-        assert isinstance(sct_ctx[chain](state), Chain)
+        assert isinstance(sct_ctx[chain](), Chain)
+        for check in dummy_checks:
+            assert getattr(sct_ctx[chain](), check)
+
+
+def test_create_embed_state(state):
+    # Given
+    state.debug = True
+    assert state.solution_result == {}
+
+    class XState(State):
+        def __init__(self, *args, custom=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.custom = custom
+
+    def derive_custom_state_args(parent_state):
+        assert parent_state == state
+        return {"student_code": "override", "custom": "Xstate property"}
+
+    # When
+    embed_state = create_embed_state(
+        XState, state, derive_custom_state_args, {"test": "nonsense highlight"},
+    )
+
+    # Then
+    assert isinstance(embed_state, XState)
+    assert not hasattr(embed_state, "debug")  # TODO
+    assert embed_state.student_code == "override"
+    assert embed_state.custom == "Xstate property"
+    assert embed_state.reporter.runner == state.reporter
+    assert embed_state.reporter.highlight_offset == {"test": "nonsense highlight"}
+    assert embed_state.creator == {"type": "embed", "args": {"state": state}}
+
+
+def test_create_embed_context(state, dummy_checks):
+    # Given
+    Ex = ExGen(state, dummy_checks)
+    assert Ex()._state == state
+
+    def derive_custom_state_args(parent_state):
+        assert parent_state == state
+        return {"student_code": "override"}
+
+    # When
+    embed_context = create_embed_context(
+        "proto", Ex(), derive_custom_state_args=derive_custom_state_args,
+    )
+
+    # Then
+    assert isinstance(embed_context["get_bash_history"](), Chain)
+    assert isinstance(embed_context["F"]().get_bash_history(), Chain)
+
+    embed_state = embed_context["Ex"].root_state
+    assert isinstance(embed_state, State)
+    assert embed_state.student_code == "override"
+    assert embed_state.reporter.runner == state.reporter
+    assert embed_state.creator == {"type": "embed", "args": {"state": state}}
+
+
+def test_get_embed_chain_constructors(state, dummy_checks):
+    # Given
+    Ex = ExGen(state, dummy_checks)
+    assert Ex()._state == state
+
+    # When
+    EmbedEx, EmbedF = get_embed_chain_constructors("proto", Ex())
+
+    # Then
+    assert isinstance(EmbedEx(), Chain)
+    assert isinstance(EmbedF(), Chain)
 
 
 def test_state_linking_root_creator(state):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,12 @@ import pytest
 from tests.helper import Success, state, dummy_checks
 from protowhat.Test import TestFail as TF
 from protowhat.sct_syntax import ExGen, F
-from protowhat.utils import legacy_signature, _debug
+from protowhat.utils import (
+    legacy_signature,
+    _debug,
+    get_class_parameters,
+    parameters_attr,
+)
 
 state = pytest.fixture(state)
 dummy_checks = pytest.fixture(dummy_checks)
@@ -39,6 +44,42 @@ def test_final_debug(state, dummy_checks):
     Ex = ExGen(state, {"_debug": _debug, **dummy_checks})
     Ex()._debug("breakpoint name", on_error=True).noop().child_state()
     assert state.reporter.fail
+
+
+def test_get_class_parameters():
+    # Given
+    class A:
+        def __init__(self, a, b="c"):
+            pass
+
+    class B(A):
+        def __init__(self, one, *args, two=2, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.one = one
+            self.two = two
+
+    # When
+    args_a = list(get_class_parameters(A))
+    args_b = list(get_class_parameters(B))
+
+    # Then
+    assert args_a == ["a", "b"]
+    assert args_b == ["a", "b", "one", "two"]
+
+
+def test_parameters_attr():
+    # Given
+    class A:
+        def __init__(self, a, b="c"):
+            pass
+
+    assert not hasattr(A, "parameters")
+
+    # When
+    A = parameters_attr(A)
+
+    # Then
+    assert A.parameters == ["a", "b"]
 
 
 def test_legacy_signature():


### PR DESCRIPTION
Currently, using one xwhat library in another one requires quite some glue code using internals of the SCT system.

~`embed_xwhat ` or~ `get_embed_chain_constructors` would be the way to use this ~, we should probably only expose one way to do this.~

This PR adds some helpers that makes it easier and more future proof to do this.

**TODO**
- [x] Decide on exposed helper.
- [x] Add tests (I first want to get feedback on the feature).
- [ ] Add a usage example.