### PR TITLE
Bumped python to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '3.5'
+- '3.7'
 install: make install
 script: make test
 deploy:

--- a/protowhat/selectors.py
+++ b/protowhat/selectors.py
@@ -1,5 +1,5 @@
 from typing import TypeVar, Generic, Union, List, Dict, Tuple
-from collections import Mapping
+from collections.abc import Mapping
 from ast import NodeVisitor
 import inspect
 import importlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # protowhat deps
-markdown2~=2.3.7
-jinja2~=2.10
-numpy
+markdown2==2.3.8
+jinja2==2.10.1
+numpy==1.17.0
 
 # test deps
-pytest~=3.5.0
-codecov~=2.0.15
-pytest-cov~=2.5.1
-bashlex~=0.12
+pytest==4.6.2
+codecov==2.0.15
+pytest-cov==2.7.1
+bashlex==0.14
 
 # building documentation
-sphinx~=1.7.4
-sphinx_rtd_theme~=0.3.1
+sphinx==2.1.2
+sphinx-rtd-theme==0.4.3

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -52,7 +52,7 @@ def temp_file_unicode():
 
 @pytest.fixture(params=["temp_file_sum", "temp_file_unicode"])
 def temp_file(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
Bumped the python version to `3.7`, upgrade the requirements in the `requirements.txt`, replaced a deprecated function, and changed an import from `collections` which will be deprecated in `3.8`.