### PR TITLE
Handle highlight position absence

### DIFF
--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -1,3 +1,6 @@
+from typing import Dict
+
+
 class Feedback:
     def __init__(self, message, state=None):
         self.message = message
@@ -10,16 +13,17 @@ class Feedback:
             if hasattr(state, "path"):
                 self.path = state.path
 
-    def _highlight_data(self):
+    def _highlight_data(self) -> Dict[str, int]:
         highlight = {}
         if self.path:
             highlight["path"] = self.path
 
         if hasattr(self.highlight, "get_position"):
-            highlight.update(self.highlight.get_position())
-            return highlight
-        elif hasattr(self.highlight, "first_token") and hasattr(
-            self.highlight, "last_token"
+            position = self.highlight.get_position()
+            if position:
+                highlight.update(position)
+        elif getattr(self.highlight, "first_token", None) and getattr(
+            self.highlight, "last_token", None
         ):
             # used by pythonwhat
             # a plugin+register system would be better
@@ -32,9 +36,10 @@ class Feedback:
                     "column_end": self.highlight.last_token.end[1],
                 }
             )
-            return highlight
 
-    def get_highlight_data(self):
+        return highlight
+
+    def get_highlight_data(self) -> Dict[str, int]:
         result = None
         if self.highlight is not None and not self.highlighting_disabled:
             result = self._highlight_data()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -131,3 +131,24 @@ def test_highlighting_path():
     }
 
     assert payload == expected_payload
+
+
+def test_highlighting_path_no_position():
+    r = Reporter()
+
+    class FeedbackState:
+        highlighting_disabled = False
+        highlight = Highlight(None)
+        path = Path("test.py")
+
+    f = Feedback("msg", FeedbackState())
+
+    payload = r.build_failed_payload(f)
+
+    expected_payload = {
+        "correct": False,
+        "message": "msg",
+        "path": "test.py",
+    }
+
+    assert payload == expected_payload


### PR DESCRIPTION
The removal of a try-catch-all in #41 results in errors for sqlwhat when updating to the latest version.
This change makes use of the more defensive approach in the latest versions of the antlr libraries.

Depends on:
- https://github.com/datacamp/antlr-ast/pull/19
- https://github.com/datacamp/antlr-plsql/pull/44
- https://github.com/datacamp/antlr-tsql/pull/43