### PR TITLE
[CX-562] ast traversal append message

### DIFF
--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -52,7 +52,7 @@ def temp_file_unicode():
 
 @pytest.fixture(params=["temp_file_sum", "temp_file_unicode"])
 def temp_file(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
Make it possible to optionally prepend messages in check_node, check_edge and has_equal_ast.