### PR TITLE
[CX-1195] Feat: validate shell commands

### DIFF
--- a/protowhat/checks/check_files.py
+++ b/protowhat/checks/check_files.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 
 from protowhat.failure import debugger
+from protowhat.State import State
 
 
 def check_file(
-    state,
+    state: State,
     path,
     missing_msg="Did you create the file `{}`?",
     is_dir_msg="Want to check the file `{}`, but found a directory.",
@@ -62,7 +63,7 @@ def check_file(
     return child_state
 
 
-def has_dir(state, path, msg="Did you create a directory `{}`?"):
+def has_dir(state: State, path, msg="Did you create a directory `{}`?"):
     """Test whether a directory exists.
 
     Args:

--- a/tests/test_check_bash_history.py
+++ b/tests/test_check_bash_history.py
@@ -14,7 +14,7 @@ from protowhat.checks.check_bash_history import (
     get_bash_history_info,
     get_bash_history,
     has_command,
-)
+    prepare_validation)
 
 
 @contextmanager
@@ -162,3 +162,12 @@ def test_has_command_custom_commands(state):
         has_command(
             state, "(a|b)+", "a and b are the best letters", commands=["old command"]
         )
+
+
+def test_prepare_validation(state):
+    state.force_diagnose = True
+    with setup_workspace():
+        update_bash_history_info()
+        prepare_validation(state, ["ls", "echo abc"])
+        has_command(state, "ls", "good job")
+        has_command(state, "echo.*c", "well done")


### PR DESCRIPTION
### Ticket
Link to ticket: https://datacamp.atlassian.net/browse/CX-1195

### What has been done
- Add the `prepare_validation` helper that executes a list of commands, only during validation, emulating a student executing commands that are expected by has_command.

### Todo
- [ ] Add test
- [ ] Update content that has an ad-hoc definition of `prepare_validation`