### PR TITLE
[CP-570] Fix space issue between feedback messages

### DIFF
--- a/protowhat/Feedback.py
+++ b/protowhat/Feedback.py
@@ -93,7 +93,8 @@ class Feedback:
                 out = Template(msg.message.replace("__JINJA__:", "")).render(tmp_kwargs)
                 out_list.append(out)
 
-        return "".join(out_list)
+        stripped_messages = [s.strip() for s in out_list]
+        return " ".join(stripped_messages)
 
     def __repr__(self):
         return "<{} {}>".format(self.__class__.__name__, repr(vars(self)))

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,16 @@
+from protowhat.Feedback import Feedback, FeedbackComponent
+
+
+def test_feedback_get_message():
+    # Given
+    conclusion = FeedbackComponent(message="    This is not good.   ")
+    fc1 = FeedbackComponent("This is worse.    ")
+    fc2 = FeedbackComponent("    This is even worse.")
+    content_components = [fc1, fc2]
+    feedback = Feedback(conclusion, content_components)
+
+    # When
+    message = feedback.get_message()
+
+    # Then
+    assert message == "This is worse. This is even worse. This is not good."


### PR DESCRIPTION
This new version of protowhat displays the feedback messages without a SPACE between them.
This PR fixes this by joining the messages on `" "` instead of `""`