### PR TITLE
[CP-4784] Add support for Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run:
@@ -17,7 +17,7 @@ jobs:
           command: python -m pytest --cov=protowhat
   publish:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ commands :
 	@grep -h -E '^##' Makefile | sed -e 's/## //g'
 
 install:
-	pip3.9 install -e .
-	pip3.9 install -r requirements.txt
+	pip3.12 install -e .
+	pip3.12 install -r requirements.txt
 
 install-test:
-	pip3.9 install -e .
-	pip3.9 install -r requirements-test.txt
+	pip3.12 install -e .
+	pip3.12 install -r requirements-test.txt
 
 ## test     : run tests.
 test :

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/protowhat.svg)](https://badge.fury.io/py/protowhat)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fdatacamp%2Fprotowhat.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fdatacamp%2Fprotowhat?ref=badge_shield)
 
-`protowhat` is a utility package required by `shellwhat` and `sqlwhat` packages, used for writing Submission Correctness Tests SCTs for interactive Shell and SQL exercises on DataCamp. It contains shared functionality related to SCT syntax, selectors and state manipulation.
+`protowhat` is a utility package required by `shellwhat`, `sqlwhat` and `pythonwhat` packages, used for writing Submission Correctness Tests SCTs for interactive Shell, SQL and Python exercises on DataCamp. It contains shared functionality related to SCT syntax, selectors and state manipulation.
 
 - If you are new to teaching on DataCamp, check out https://instructor-support.datacamp.com.
 - If you want to learn what SCTs are and how they work, visit [this article](https://instructor-support.datacamp.com/courses/course-development/submission-correctness-tests) specifically.
@@ -12,18 +12,19 @@
 ## Installation
 
 ```
-pyenv local 3.9.0
-pip3.9 install protowhat   # install from pypi
+pyenv local 3.12.7
+pip3.12 install protowhat   # install from pypi
 make install            # install from source
 ```
 
 ## Testing
 
 ```
-pip3.9 install -e .
+pip3.12 install -r requirements-test.txt
+pip3.12 install -e .
 pytest
 ```
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fdatacamp%2Fprotowhat.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fdatacamp%2Fprotowhat?ref=badge_large)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-pytest~=6.2.5
-pytest-cov~=2.12.1
+pytest~=8.1.1
+pytest-cov~=6.1.1
 bashlex~=0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-markdown2==2.4.13
-Pygments==2.13.0
-jinja2~=3.1.2
-markupsafe==2.1.3
+markdown2==2.5.3
+jinja2==3.1.3

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -10,7 +10,7 @@ Constant._priority = 1
 
 @pytest.fixture
 def node():
-    return Expr(value=Constant(n=1))
+    return Expr(value=Constant(value=1))
 
 
 def test_selector_standalone(node):


### PR DESCRIPTION
https://datacamp.atlassian.net/browse/CP-4784

- Updates documentation to instruct to use Python 3.12.7
- Updates CI to run on Python 3.12
- Fixes documentation to include missing step for installing test dependencies and to mention this project is used by pythonwhat
- Updates dependencies
- Resolves a deprecation warning